### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,8 @@ on:
 jobs:
   build:
     runs-on: macos-15  # Apple Silicon runner with Swift 6
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
Potential fix for [https://github.com/abdul-abdi/lumina/security/code-scanning/1](https://github.com/abdul-abdi/lumina/security/code-scanning/1)

To fix this, explicitly set minimal `GITHUB_TOKEN` permissions in the workflow. Since this job only checks out the repository, builds, and runs tests, it only needs read access to repository contents. The recommended minimal configuration is `contents: read`. You can set this either at the workflow root (applies to all jobs) or within the specific `build` job. To avoid changing behavior elsewhere and to directly address the flagged job, define permissions inside the `build` job.

Concretely, in `.github/workflows/ci.yml`, add a `permissions:` section under `jobs.build` (at the same indentation level as `runs-on`) and set `contents: read`. No imports, methods, or additional definitions are required; this is purely a YAML configuration change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
