### PR TITLE
feat: Lumina v0.3.0 — sessions, custom images, volumes, networking

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,39 +9,67 @@ lumina/
 ├── Package.swift                    # Swift package manifest (SPM)
 ├── Sources/
 │   ├── Lumina/                      # Library target
-│   │   ├── Lumina.swift             # Convenience API (Lumina.run, Lumina.stream)
+│   │   ├── Lumina.swift             # Convenience API (run, stream, createImage, withNetwork)
 │   │   ├── VM.swift                 # VM actor (VZVirtualMachine lifecycle)
 │   │   ├── CommandRunner.swift      # vsock protocol + state machine
-│   │   ├── ImageStore.swift         # Image cache (~/.lumina/images/)
+│   │   ├── ImageStore.swift         # Image cache + custom image creation (~/.lumina/images/)
+│   │   ├── ImagePuller.swift        # Downloads default image from GitHub Releases
 │   │   ├── DiskClone.swift          # Per-run COW clone management
+│   │   ├── InitrdPatcher.swift      # Initramfs overlay (agent injection, network config)
 │   │   ├── SerialConsole.swift      # Serial console capture
-│   │   └── Types.swift              # RunResult, RunOptions, OutputChunk, LuminaError, VMState
+│   │   ├── Protocol.swift           # vsock message types + codec
+│   │   ├── NetworkProvider.swift    # Network attachment protocol (NAT, file-handle)
+│   │   ├── Session.swift            # SessionPaths — filesystem layout for sessions
+│   │   ├── SessionProtocol.swift    # Session IPC codec (NDJSON over Unix socket)
+│   │   ├── SessionServer.swift      # Unix socket listener for session processes
+│   │   ├── SessionClient.swift      # Unix socket client for CLI commands
+│   │   ├── NetworkSwitch.swift      # SOCK_DGRAM ethernet frame relay
+│   │   ├── Network.swift            # Network actor — manages VM groups on shared switch
+│   │   ├── VolumeStore.swift        # Named persistent volumes (~/.lumina/volumes/)
+│   │   └── Types.swift              # RunResult, RunOptions, VMOptions, SessionOptions, etc.
 │   └── lumina-cli/                  # CLI executable target
-│       └── main.swift               # swift-argument-parser wrapper
+│       ├── CLI.swift                # ArgumentParser commands (run, session, exec, images, etc.)
+│       ├── Helpers.swift            # Shared CLI helpers (signal handlers, output format)
+│       └── SessionProcess.swift     # Hidden _session-serve background process
 ├── Guest/
 │   ├── lumina-agent/                # Guest agent (Go, linux/arm64)
 │   │   ├── main.go
 │   │   └── go.mod
 │   └── build-image.sh              # Alpine image builder script
 ├── Tests/
-│   └── LuminaTests/                # XCTest suite
-│       ├── LuminaRunTests.swift     # Integration tests (require real VM)
-│       ├── ProtocolTests.swift      # Unit tests for vsock protocol parsing
-│       └── DiskCloneTests.swift     # COW clone create/remove/orphan tests
+│   └── LuminaTests/                # swift-testing suite
+│       ├── IntegrationTests.swift   # Full Lumina.run() tests (require real VM)
+│       ├── ProtocolTests.swift      # vsock protocol parsing
+│       ├── DiskCloneTests.swift     # COW clone create/remove/orphan
+│       ├── SessionTests.swift       # Session types, SessionPaths
+│       ├── SessionProtocolTests.swift  # Session IPC codec
+│       ├── SessionServerTests.swift # Unix socket bind/accept
+│       ├── SessionClientTests.swift # Client connect error paths
+│       ├── ImageStoreTests.swift    # Image creation/removal/inspect
+│       ├── VolumeStoreTests.swift   # Volume CRUD
+│       ├── NetworkSwitchTests.swift # SOCK_DGRAM relay, IP assignment
+│       ├── NetworkTests.swift       # Network overlay, VMOptions defaults
+│       ├── TypesTests.swift         # Type defaults, parsing helpers
+│       ├── ParsingTests.swift       # Duration/memory parsing
+│       └── SerialConsoleTests.swift # Serial console append/output
 └── .github/workflows/ci.yml        # Build + test on macOS
 ```
 
 ## Architecture
 
-Two-layer API:
+Three-layer API:
 - **Layer 1 (Convenience):** `Lumina.run()` / `Lumina.stream()` — boot, exec, teardown in one call
-- **Layer 2 (Lifecycle):** `VM` actor — explicit `boot()`, `exec()`, `shutdown()` for power users
+- **Layer 2 (Sessions):** `session start/stop/list`, `exec` — persistent VMs with Unix socket IPC
+- **Layer 3 (Lifecycle):** `VM` actor — explicit `boot()`, `exec()`, `shutdown()` for power users
 
-Four internal components:
+Seven internal components:
 - **VM** — actor wrapping `VZVirtualMachine`, pinned to dedicated executor (thread affinity)
 - **CommandRunner** — vsock protocol over port 1024, explicit `ConnectionState` state machine
-- **ImageStore** — long-lived image cache at `~/.lumina/images/`
+- **ImageStore** — long-lived image cache at `~/.lumina/images/`, custom image creation with staging-dir atomicity
 - **DiskClone** — per-run ephemeral COW clones at `~/.lumina/runs/<uuid>/`
+- **SessionServer/Client** — Unix domain socket IPC for persistent sessions at `~/.lumina/sessions/<sid>/`
+- **VolumeStore** — named persistent volumes at `~/.lumina/volumes/<name>/data/`
+- **NetworkSwitch** — SOCK_DGRAM ethernet frame relay for VM-to-VM networking
 
 ### Architecture Rules
 
@@ -49,6 +77,10 @@ Four internal components:
 - `CommandRunner` models connection state explicitly via `ConnectionState` enum — no implicit state transitions.
 - `DiskClone` and `ImageStore` are separate concerns. DiskClone handles per-run ephemeral copies; ImageStore handles the long-lived cache. Do not merge them.
 - No shared mutable state between concurrent runs. Each `Lumina.run()` creates its own VM actor, COW clone, and vsock connection.
+- `SessionServer` and `SessionClient` communicate via NDJSON over Unix domain sockets. One client at a time per session.
+- `VolumeStore` and `ImageStore` are separate concerns. VolumeStore manages named host directories; ImageStore manages image caches with staging-dir atomicity.
+- `NetworkSwitch` reads ports under lock each iteration of the relay loop (not a one-time snapshot) to support dynamic VM join.
+- `VMOptions.privateNetworkFd` is `Int32?` not `FileHandle?` — FileHandle isn't Sendable in Swift 6.
 - All public types must be `Sendable`.
 - Zero external Swift package dependencies beyond `swift-argument-parser` (CLI only). The library target links only Apple frameworks (`Virtualization`).
 
@@ -59,37 +91,78 @@ Newline-delimited JSON over `VZVirtioSocketDevice`, port 1024, max 64KB per mess
 - Host sends `{"type":"exec","cmd":"...","timeout":N,"env":{...}}`
 - Guest streams `{"type":"output","stream":"stdout|stderr","data":"..."}` then `{"type":"exit","code":N}`
 
+### Session IPC Protocol
+
+NDJSON over Unix domain socket at `~/.lumina/sessions/<sid>/control.sock`, max 64KB per message.
+- Client sends `SessionRequest`: exec, upload, download, shutdown
+- Server sends `SessionResponse`: output, exit, error, uploadDone, downloadDone
+
 ## Dev Commands
 
 ```bash
-# Build
-swift build
+# Build (debug + codesign with entitlements)
+make build
 
-# Test (unit + integration — integration requires macOS + Apple Silicon)
-swift test
+# Build release + codesign
+make release
 
-# Test with verbose output
-swift test --verbose
+# Install to ~/.local/bin (or: make install PREFIX=/usr/local)
+make install
 
-# Type check only (no link)
-swift build 2>&1 | head -50   # Swift compiler is the type checker
+# Run unit tests
+make test
 
-# Build guest agent (cross-compile Go for linux/arm64)
+# Run e2e integration tests (requires VM image + jq)
+make test-integration
+
+# Build, sign, and run with args
+make run ARGS="echo hello"
+
+# Clean build artifacts
+make clean
+
+# Build guest agent (cross-compile Go → linux/arm64)
 cd Guest/lumina-agent && CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build -ldflags="-s -w" -o lumina-agent
 
-# Build Alpine image
+# Build Alpine image (requires e2fsprogs: brew install e2fsprogs)
 cd Guest && bash build-image.sh
+```
 
-# Run CLI
-swift run lumina run "echo hello"
-swift run lumina run --stream "make build"
+### CLI Commands
+
+```bash
+# Disposable VM
+lumina run "echo hello"
+lumina run --stream "make build"
+lumina run --volume mydata:/data "ls /data"
+
+# Sessions (persistent VM)
+lumina session start --image default
+lumina exec <sid> "echo hello"
+lumina session list
+lumina session stop <sid>
+
+# Images
+lumina images list
+lumina images create python --from default --run "apk add python3"
+lumina images inspect python
+lumina images remove python
+
+# Volumes
+lumina volume create mydata
+lumina volume list
+lumina volume inspect mydata
+lumina volume remove mydata
+
+# Networking
+lumina network run --file manifest.json
 ```
 
 ## Testing Conventions
 
-- Runner: `swift test` (XCTest)
+- Runner: `swift test` (swift-testing framework, `@Test func` syntax)
 - Location: `Tests/LuminaTests/`
-- Unit tests: protocol parsing, type defaults, DiskClone paths, ConnectionState transitions
+- Unit tests: protocol parsing, type defaults, DiskClone paths, session types, session protocol codec, socket bind/accept, volume CRUD, network switch relay, image creation
 - Integration tests: full `Lumina.run()` with real VMs (require Apple Silicon + macOS host)
 - Name test files `<Component>Tests.swift`
 - Target 80% coverage on unit-testable code
@@ -100,7 +173,7 @@ swift run lumina run --stream "make build"
 1. Add field to `RunOptions` and `VMOptions` in `Types.swift`
 2. Wire it through `VMOptions(from:)` conversion
 3. Apply it in `VM.boot()` where `VZVirtualMachineConfiguration` is built
-4. Add CLI flag in `main.swift` via ArgumentParser
+4. Add CLI flag in `CLI.swift` via ArgumentParser
 5. Add unit test for default value, integration test for behavior
 
 **Adding a new protocol message type:**
@@ -112,20 +185,20 @@ swift run lumina run --stream "make build"
 ## Proactive Checks
 
 After editing Swift files in `Sources/` or `Tests/`:
-- Run `swift build` to catch compilation errors
-- Run unit tests only for fast feedback: `swift test --filter ProtocolTests` or `swift test --filter DiskCloneTests`
-- Only run full `swift test` when changing integration-level code (VM, Lumina.swift) or before completing a task
+- Run `make build` to catch compilation errors (includes codesign)
+- Run unit tests only for fast feedback: `swift test --filter ProtocolTests`, `swift test --filter SessionTests`, `swift test --filter NetworkSwitchTests`, etc.
+- Only run full `make test` when changing integration-level code (VM, Lumina.swift) or before completing a task
 
 After editing Go files in `Guest/lumina-agent/`:
 - Run `cd Guest/lumina-agent && CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build -ldflags="-s -w" -o lumina-agent` to verify it compiles
 
 Before completing any task:
-- Run `swift build` (must succeed with zero errors)
-- Run `swift test` (all tests must pass — unit AND integration)
+- Run `make build` (must succeed with zero errors)
+- Run `make test` (all tests must pass — unit AND integration)
 - Verify no `Sendable` warnings — all public types must conform
 
 Before committing:
-- Run `swift build && swift test`
+- Run `make build && make test`
 - Ensure commit message follows `<type>: <description>` format
 - Do NOT commit until user approves
 

--- a/Sources/Lumina/ImageStore.swift
+++ b/Sources/Lumina/ImageStore.swift
@@ -59,11 +59,126 @@ public struct ImageStore: Sendable {
         return entries
             .filter { (try? $0.resourceValues(forKeys: [.isDirectoryKey]).isDirectory) == true }
             .map { $0.lastPathComponent }
+            .filter { !$0.hasPrefix(".tmp-") }
             .sorted()
     }
 
     public func clean(name: String) {
         let dir = baseDir.appendingPathComponent(name)
         try? FileManager.default.removeItem(at: dir)
+    }
+
+    /// Create a new named image from a base image and a modified rootfs.
+    /// Uses staging-dir + atomic rename for crash safety.
+    public func createImage(
+        name: String,
+        from base: String,
+        rootfsSource: URL,
+        command: String
+    ) throws {
+        let fm = FileManager.default
+
+        // Validate base exists
+        let baseImageDir = baseDir.appendingPathComponent(base)
+        guard fm.fileExists(atPath: baseImageDir.appendingPathComponent("rootfs.img").path) else {
+            throw LuminaError.imageNotFound(base)
+        }
+
+        // Staging dir for atomic creation
+        let stagingId = UUID().uuidString
+        let stagingDir = baseDir.appendingPathComponent(".tmp-\(stagingId)")
+
+        do {
+            try fm.createDirectory(at: stagingDir, withIntermediateDirectories: true)
+
+            // Copy modified rootfs
+            try fm.copyItem(at: rootfsSource, to: stagingDir.appendingPathComponent("rootfs.img"))
+
+            // Symlink shared assets from base
+            for asset in ["vmlinuz", "initrd", "lumina-agent"] {
+                let source = baseImageDir.appendingPathComponent(asset)
+                if fm.fileExists(atPath: source.path) {
+                    try fm.createSymbolicLink(
+                        at: stagingDir.appendingPathComponent(asset),
+                        withDestinationURL: source
+                    )
+                }
+            }
+
+            // Symlink modules directory
+            let baseModules = baseImageDir.appendingPathComponent("modules")
+            if fm.fileExists(atPath: baseModules.path) {
+                try fm.createSymbolicLink(
+                    at: stagingDir.appendingPathComponent("modules"),
+                    withDestinationURL: baseModules
+                )
+            }
+
+            // Write meta.json
+            let meta = ImageMeta(base: base, command: command, created: Date())
+            let metaData = try JSONEncoder().encode(meta)
+            try metaData.write(to: stagingDir.appendingPathComponent("meta.json"))
+
+            // Atomic rename to final location
+            let finalDir = self.baseDir.appendingPathComponent(name)
+            try fm.moveItem(at: stagingDir, to: finalDir)
+        } catch let error as LuminaError {
+            try? fm.removeItem(at: stagingDir)
+            throw error
+        } catch {
+            try? fm.removeItem(at: stagingDir)
+            throw LuminaError.cloneFailed(underlying: error)
+        }
+    }
+
+    /// Remove a named image. Refuses if other images depend on it.
+    public func removeImage(name: String) throws {
+        let allNames = list()
+        for other in allNames where other != name {
+            let metaFile = baseDir.appendingPathComponent(other).appendingPathComponent("meta.json")
+            if let data = try? Data(contentsOf: metaFile),
+               let meta = try? JSONDecoder().decode(ImageMeta.self, from: data),
+               meta.base == name {
+                throw LuminaError.sessionFailed("Cannot remove '\(name)': image '\(other)' depends on it")
+            }
+        }
+        let dir = baseDir.appendingPathComponent(name)
+        try FileManager.default.removeItem(at: dir)
+    }
+
+    /// Inspect an image -- returns metadata and size.
+    public func inspect(name: String) throws -> ImageInfo {
+        let dir = baseDir.appendingPathComponent(name)
+        let metaFile = dir.appendingPathComponent("meta.json")
+        let rootfs = dir.appendingPathComponent("rootfs.img")
+
+        guard FileManager.default.fileExists(atPath: rootfs.path) else {
+            throw LuminaError.imageNotFound(name)
+        }
+
+        var base: String? = nil
+        var command: String? = nil
+        var created = Date()
+
+        if let data = try? Data(contentsOf: metaFile),
+           let meta = try? JSONDecoder().decode(ImageMeta.self, from: data) {
+            base = meta.base
+            command = meta.command
+            created = meta.created
+        }
+
+        let attrs = try? FileManager.default.attributesOfItem(atPath: rootfs.path)
+        let size = attrs?[.size] as? UInt64 ?? 0
+
+        return ImageInfo(name: name, base: base, command: command, created: created, sizeBytes: size)
+    }
+
+    /// Clean up staging directories left by crashed image creation attempts.
+    public func cleanStagingDirs() {
+        let fm = FileManager.default
+        guard let entries = try? fm.contentsOfDirectory(at: baseDir, includingPropertiesForKeys: nil) else { return }
+        for entry in entries where entry.lastPathComponent.hasPrefix(".tmp-") {
+            try? fm.removeItem(at: entry)
+        }
     }
 }

--- a/Sources/Lumina/InitrdPatcher.swift
+++ b/Sources/Lumina/InitrdPatcher.swift
@@ -208,6 +208,11 @@ enum InitrdPatcher {
             "  IFS=\"$OLD_IFS\"",
             "fi",
             "",
+            "# Source network init if present (injected by appendNetworkOverlay)",
+            "if [ -f /lumina-net-init ]; then",
+            "  . /lumina-net-init",
+            "fi",
+            "",
             "exec /usr/local/bin/lumina-agent",
             "INITEOF",
             "chmod 755 /sysroot/sbin/lumina-init",
@@ -217,6 +222,52 @@ enum InitrdPatcher {
         ]
 
         return lines.joined(separator: "\n") + "\n"
+    }
+
+    /// Append a network overlay to an existing combined initrd.
+    /// Adds /lumina-hosts file and eth1 configuration to the init script.
+    /// Called AFTER createCombinedInitrd, composes on top of it.
+    static func appendNetworkOverlay(
+        initrdURL: URL,
+        hosts: [String: String],
+        ip: String
+    ) throws(LuminaError) {
+        var cpio = Data()
+        cpio.append(cpioEntry(path: ".", mode: 0o40755, data: Data()))
+
+        // /lumina-hosts file
+        var hostsContent = "127.0.0.1 localhost\n"
+        for (name, addr) in hosts.sorted(by: { $0.key < $1.key }) {
+            hostsContent += "\(addr) \(name)\n"
+        }
+        cpio.append(cpioEntry(path: "lumina-hosts", mode: 0o100644, data: Data(hostsContent.utf8)))
+
+        // /lumina-net-init script (sourced by the main init if present)
+        let netInit = """
+        #!/bin/sh
+        # Configure eth1 for private networking
+        ip addr add "\(ip)/24" dev eth1 2>/dev/null
+        ip link set eth1 up 2>/dev/null
+        # Copy network hosts file
+        if [ -f /lumina-hosts ]; then
+            cp /lumina-hosts /etc/hosts
+        fi
+        """
+        cpio.append(cpioEntry(path: "lumina-net-init", mode: 0o100755, data: Data(netInit.utf8)))
+
+        cpio.append(cpioTrailer())
+
+        let compressedCpio = try gzipCompress(cpio, tempDir: initrdURL.deletingLastPathComponent())
+
+        // Append to existing initrd (Linux supports concatenated initramfs)
+        do {
+            let handle = try FileHandle(forWritingTo: initrdURL)
+            handle.seekToEndOfFile()
+            handle.write(compressedCpio)
+            try handle.close()
+        } catch {
+            throw .bootFailed(underlying: PatcherError.writeFailed("network overlay: \(error)"))
+        }
     }
 
     // MARK: - CPIO newc format

--- a/Sources/Lumina/Lumina.swift
+++ b/Sources/Lumina/Lumina.swift
@@ -88,11 +88,35 @@ public struct Lumina {
         }
     }
 
-    // MARK: - Private
+    /// Create a custom image by running a command in a disposable VM.
+    public static func createImage(
+        name: String,
+        from base: String = "default",
+        command: String,
+        options: RunOptions = .default
+    ) async throws {
+        var opts = options
+        opts.image = base
+        let resolvedOpts = opts
+        try await withVM(options: resolvedOpts) { vm in
+            try await vm.bootResult().get()
+            let result = try await vm.execResult(command, timeout: Int(resolvedOpts.timeout.components.seconds), env: resolvedOpts.env).get()
+            guard result.success else {
+                throw LuminaError.sessionFailed("Image build command failed with exit code \(result.exitCode): \(result.stderr)")
+            }
+            guard let clone = await vm.diskClone else {
+                throw LuminaError.sessionFailed("No disk clone available")
+            }
+            let store = ImageStore()
+            try store.createImage(name: name, from: base, rootfsSource: clone.rootfs, command: command)
+        }
+    }
+
+    // MARK: - Internal
 
     /// Lifecycle scope: creates a VM, runs the body, and always shuts down.
     /// One shutdown call site, guaranteed to run on every path.
-    private static func withVM<T: Sendable>(
+    static func withVM<T: Sendable>(
         options: RunOptions,
         body: @Sendable (VM) async throws -> T
     ) async throws -> T {

--- a/Sources/Lumina/Lumina.swift
+++ b/Sources/Lumina/Lumina.swift
@@ -112,6 +112,23 @@ public struct Lumina {
         }
     }
 
+    /// Run a closure with a private network of VMs.
+    /// All VMs share a virtual switch for VM-to-VM communication.
+    public static func withNetwork<T: Sendable>(
+        _ name: String = "default",
+        body: @Sendable (Network) async throws -> T
+    ) async throws -> T {
+        let network = Network(name: name)
+        do {
+            let result = try await body(network)
+            await network.shutdown()
+            return result
+        } catch {
+            await network.shutdown()
+            throw error
+        }
+    }
+
     // MARK: - Internal
 
     /// Lifecycle scope: creates a VM, runs the body, and always shuts down.

--- a/Sources/Lumina/Network.swift
+++ b/Sources/Lumina/Network.swift
@@ -1,0 +1,57 @@
+// Sources/Lumina/Network.swift
+import Foundation
+
+/// Manages a group of VMs on a shared private network.
+/// All VMs are booted within a single process — no cross-process networking.
+public actor Network {
+    private let name: String
+    private let networkSwitch: NetworkSwitch
+    private var sessions: [(name: String, ip: String, vm: VM)] = []
+
+    public init(name: String) {
+        self.name = name
+        self.networkSwitch = NetworkSwitch()
+    }
+
+    /// Boot a new VM on the network.
+    public func session(
+        name sessionName: String,
+        image: String = "default",
+        options: VMOptions = .default
+    ) async throws -> VM {
+        let index = sessions.count
+        let ip = NetworkSwitch.ipForIndex(index)
+
+        let port = try networkSwitch.createPort()
+
+        var allPeers = sessions.map { ($0.name, $0.ip) }
+        allPeers.append((sessionName, ip))
+        let hostsMap = Dictionary(uniqueKeysWithValues: allPeers.map { ($0.0, $0.1) })
+
+        var vmOpts = options
+        vmOpts.image = image
+        vmOpts.privateNetworkFd = port.vmFd
+        vmOpts.networkHosts = hostsMap
+        vmOpts.networkIP = ip
+
+        let vm = VM(options: vmOpts)
+        try await vm.bootResult().get()
+
+        sessions.append((name: sessionName, ip: ip, vm: vm))
+
+        if sessions.count == 2 {
+            networkSwitch.startRelay()
+        }
+
+        return vm
+    }
+
+    /// Shutdown all VMs and close the network.
+    public func shutdown() async {
+        for (_, _, vm) in sessions {
+            await vm.shutdown()
+        }
+        networkSwitch.close()
+        sessions = []
+    }
+}

--- a/Sources/Lumina/NetworkSwitch.swift
+++ b/Sources/Lumina/NetworkSwitch.swift
@@ -1,0 +1,124 @@
+// Sources/Lumina/NetworkSwitch.swift
+import Foundation
+
+/// A port on the virtual switch — one end for the VM, one for the relay.
+public struct SwitchPort: Sendable {
+    /// File descriptor given to VZFileHandleNetworkDeviceAttachment (VM side)
+    public let vmFd: Int32
+    /// File descriptor owned by NetworkSwitch (relay side)
+    public let switchFd: Int32
+}
+
+/// Userspace ethernet frame relay using SOCK_DGRAM socketpairs.
+/// VZFileHandleNetworkDeviceAttachment requires datagram sockets because
+/// VZ writes complete Ethernet frames as individual datagrams.
+public final class NetworkSwitch: @unchecked Sendable {
+    private let lock = NSLock()
+    private var ports: [SwitchPort] = []
+    private var relayThread: Thread?
+    private var running = false
+
+    public init() {}
+
+    /// Create a new port on the switch. Returns a pair of fds:
+    /// vmFd goes to VZFileHandleNetworkDeviceAttachment,
+    /// switchFd is used by the relay loop.
+    public func createPort() throws -> SwitchPort {
+        var fds: [Int32] = [0, 0]
+        guard socketpair(AF_UNIX, SOCK_DGRAM, 0, &fds) == 0 else {
+            throw LuminaError.sessionFailed("Failed to create SOCK_DGRAM socketpair: \(errno)")
+        }
+        let port = SwitchPort(vmFd: fds[0], switchFd: fds[1])
+        lock.lock()
+        ports.append(port)
+        lock.unlock()
+        return port
+    }
+
+    /// Start the relay loop on a background thread.
+    /// Reads datagrams from each port's switchFd and writes to all other ports.
+    public func startRelay() {
+        lock.lock()
+        running = true
+        lock.unlock()
+
+        let thread = Thread {
+            self.relayLoop()
+        }
+        thread.qualityOfService = .userInitiated
+        thread.start()
+        relayThread = thread
+    }
+
+    /// Stop the relay and close all fds.
+    public func close() {
+        lock.lock()
+        running = false
+        let currentPorts = ports
+        ports = []
+        lock.unlock()
+
+        for port in currentPorts {
+            Darwin.close(port.vmFd)
+            Darwin.close(port.switchFd)
+        }
+    }
+
+    // MARK: - IP Assignment
+
+    /// Deterministic IP for a session index (0-based).
+    /// Range: 192.168.100.2 through 192.168.100.254
+    public static func ipForIndex(_ index: Int) -> String {
+        "192.168.100.\(index + 2)"
+    }
+
+    /// Generate /etc/hosts content for all peers.
+    public static func generateHosts(peers: [(name: String, ip: String)]) -> String {
+        var lines = ["127.0.0.1 localhost"]
+        for peer in peers {
+            lines.append("\(peer.ip) \(peer.name)")
+        }
+        return lines.joined(separator: "\n") + "\n"
+    }
+
+    // MARK: - Private
+
+    private func relayLoop() {
+        let maxFrame = 1514 // Max ethernet frame size
+        var buffer = [UInt8](repeating: 0, count: maxFrame)
+        var knownFds: Set<Int32> = []
+
+        while running {
+            // Read ports under lock each iteration — picks up newly added ports
+            lock.lock()
+            let currentPorts = ports
+            lock.unlock()
+
+            // Set any new fds to non-blocking
+            for port in currentPorts where !knownFds.contains(port.switchFd) {
+                let flags = fcntl(port.switchFd, F_GETFL)
+                fcntl(port.switchFd, F_SETFL, flags | O_NONBLOCK)
+                knownFds.insert(port.switchFd)
+            }
+
+            var didWork = false
+
+            for (i, srcPort) in currentPorts.enumerated() {
+                let n = Darwin.read(srcPort.switchFd, &buffer, maxFrame)
+                if n > 0 {
+                    didWork = true
+                    // Broadcast to all other ports
+                    for (j, dstPort) in currentPorts.enumerated() where j != i {
+                        _ = buffer.withUnsafeBufferPointer { buf in
+                            Darwin.write(dstPort.switchFd, buf.baseAddress!, n)
+                        }
+                    }
+                }
+            }
+
+            if !didWork {
+                usleep(1000) // 1ms — avoid busy-spinning
+            }
+        }
+    }
+}

--- a/Sources/Lumina/Session.swift
+++ b/Sources/Lumina/Session.swift
@@ -1,0 +1,66 @@
+// Sources/Lumina/Session.swift
+import Foundation
+
+public struct SessionPaths: Sendable {
+    public let sid: String
+    public let directory: URL
+    public let socket: URL
+    public let metaFile: URL
+    public let runDir: URL
+
+    public static let defaultSessionsDir: URL = {
+        FileManager.default.homeDirectoryForCurrentUser
+            .appendingPathComponent(".lumina/sessions")
+    }()
+
+    public init(sid: String, sessionsDir: URL = SessionPaths.defaultSessionsDir) {
+        self.sid = sid
+        self.directory = sessionsDir.appendingPathComponent(sid)
+        self.socket = self.directory.appendingPathComponent("control.sock")
+        self.metaFile = self.directory.appendingPathComponent("meta.json")
+        self.runDir = self.directory.appendingPathComponent("run")
+    }
+
+    /// Write session metadata to disk.
+    public func writeMeta(_ info: SessionInfo) throws {
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        let data = try JSONEncoder().encode(info)
+        try data.write(to: metaFile)
+    }
+
+    /// Read session metadata from disk. Returns nil if file doesn't exist.
+    public func readMeta() -> SessionInfo? {
+        guard let data = try? Data(contentsOf: metaFile) else { return nil }
+        return try? JSONDecoder().decode(SessionInfo.self, from: data)
+    }
+
+    /// Check if the session's process is alive.
+    public func isAlive() -> Bool {
+        guard let info = readMeta() else { return false }
+        return kill(info.pid, 0) == 0
+    }
+
+    /// Remove the session directory and all contents.
+    public func cleanup() {
+        try? FileManager.default.removeItem(at: directory)
+    }
+
+    /// List all sessions, checking liveness.
+    public static func listAll(sessionsDir: URL = SessionPaths.defaultSessionsDir) -> [SessionInfo] {
+        let fm = FileManager.default
+        guard let entries = try? fm.contentsOfDirectory(
+            at: sessionsDir,
+            includingPropertiesForKeys: [.isDirectoryKey]
+        ) else { return [] }
+
+        return entries.compactMap { entry -> SessionInfo? in
+            let sid = entry.lastPathComponent
+            let paths = SessionPaths(sid: sid, sessionsDir: sessionsDir)
+            guard var info = paths.readMeta() else { return nil }
+            if kill(info.pid, 0) != 0 {
+                info.status = .dead
+            }
+            return info
+        }.sorted { $0.created < $1.created }
+    }
+}

--- a/Sources/Lumina/SessionClient.swift
+++ b/Sources/Lumina/SessionClient.swift
@@ -1,0 +1,133 @@
+// Sources/Lumina/SessionClient.swift
+import Foundation
+
+/// Connects to a session's Unix domain socket and sends/receives
+/// SessionProtocol messages. Used by the CLI `exec` and `session stop` commands.
+public final class SessionClient: @unchecked Sendable {
+    private let sessionsDir: URL
+    private var clientFd: Int32 = -1
+    private var readHandle: FileHandle?
+    private var writeHandle: FileHandle?
+
+    public init(sessionsDir: URL = SessionPaths.defaultSessionsDir) {
+        self.sessionsDir = sessionsDir
+    }
+
+    /// Connect to a session by ID. Validates the session exists and is alive.
+    public func connect(sid: String) throws {
+        let paths = SessionPaths(sid: sid, sessionsDir: sessionsDir)
+
+        // Check if session directory exists
+        guard FileManager.default.fileExists(atPath: paths.directory.path) else {
+            throw LuminaError.sessionNotFound(sid)
+        }
+
+        // Check if session process is alive
+        if let info = paths.readMeta(), kill(info.pid, 0) != 0 {
+            paths.cleanup()
+            throw LuminaError.sessionDead(sid)
+        }
+
+        // Connect to Unix socket
+        clientFd = socket(AF_UNIX, SOCK_STREAM, 0)
+        guard clientFd >= 0 else {
+            throw LuminaError.sessionFailed("Failed to create socket: \(errno)")
+        }
+
+        var addr = sockaddr_un()
+        addr.sun_family = sa_family_t(AF_UNIX)
+        let pathStr = paths.socket.path
+        let pathBytes = pathStr.utf8CString
+        withUnsafeMutablePointer(to: &addr.sun_path) { ptr in
+            ptr.withMemoryRebound(to: CChar.self, capacity: 104) { dest in
+                pathBytes.withUnsafeBufferPointer { src in
+                    let count = min(src.count, 104)
+                    dest.update(from: src.baseAddress!, count: count)
+                }
+            }
+        }
+
+        let connectResult = withUnsafePointer(to: &addr) { ptr in
+            ptr.withMemoryRebound(to: sockaddr.self, capacity: 1) { sockPtr in
+                Darwin.connect(clientFd, sockPtr, socklen_t(MemoryLayout<sockaddr_un>.size))
+            }
+        }
+        guard connectResult == 0 else {
+            Darwin.close(clientFd)
+            clientFd = -1
+            // Socket exists but can't connect -- session may be dead
+            if !paths.isAlive() {
+                paths.cleanup()
+                throw LuminaError.sessionDead(sid)
+            }
+            throw LuminaError.sessionFailed("Failed to connect to session \(sid): \(errno)")
+        }
+
+        readHandle = FileHandle(fileDescriptor: clientFd, closeOnDealloc: false)
+        writeHandle = FileHandle(fileDescriptor: clientFd, closeOnDealloc: false)
+    }
+
+    /// Send a request to the session server.
+    public func send(_ request: SessionRequest) throws {
+        guard let handle = writeHandle else {
+            throw LuminaError.connectionFailed
+        }
+        let data = try SessionProtocol.encode(request)
+        handle.write(data)
+    }
+
+    /// Read one response from the session server.
+    public func receive() throws -> SessionResponse {
+        guard let handle = readHandle else {
+            throw LuminaError.connectionFailed
+        }
+        var buffer = Data()
+        while true {
+            let chunk = handle.availableData
+            if chunk.isEmpty {
+                throw LuminaError.connectionFailed
+            }
+            buffer.append(chunk)
+            if buffer.count > SessionProtocol.maxMessageSize {
+                throw LuminaError.protocolError("Session response exceeds 64KB")
+            }
+            if buffer.firstIndex(of: UInt8(ascii: "\n")) != nil {
+                return try SessionProtocol.decodeResponse(buffer)
+            }
+        }
+    }
+
+    /// Execute a command and yield all responses until exit or error.
+    public func exec(
+        cmd: String,
+        timeout: Int = 60,
+        env: [String: String] = [:]
+    ) throws -> [SessionResponse] {
+        try send(.exec(cmd: cmd, timeout: timeout, env: env))
+        var responses: [SessionResponse] = []
+        while true {
+            let response = try receive()
+            responses.append(response)
+            switch response {
+            case .exit, .error:
+                return responses
+            default:
+                continue
+            }
+        }
+    }
+
+    /// Disconnect from the session.
+    public func disconnect() {
+        if clientFd >= 0 {
+            Darwin.close(clientFd)
+            clientFd = -1
+        }
+        readHandle = nil
+        writeHandle = nil
+    }
+
+    deinit {
+        disconnect()
+    }
+}

--- a/Sources/Lumina/SessionProtocol.swift
+++ b/Sources/Lumina/SessionProtocol.swift
@@ -1,0 +1,140 @@
+// Sources/Lumina/SessionProtocol.swift
+import Foundation
+
+// MARK: - Session Request (host → session server)
+
+public enum SessionRequest: Sendable, Equatable {
+    case exec(cmd: String, timeout: Int, env: [String: String])
+    case upload(localPath: String, remotePath: String)
+    case download(remotePath: String, localPath: String)
+    case shutdown
+}
+
+// MARK: - Session Response (session server → host)
+
+public enum SessionResponse: Sendable, Equatable {
+    case output(stream: OutputStream, data: String)
+    case exit(code: Int32, durationMs: Int)
+    case error(message: String)
+    case uploadDone(path: String)
+    case downloadDone(path: String)
+}
+
+// MARK: - Codec
+
+public enum SessionProtocol {
+    static let maxMessageSize = 65_536
+
+    public static func encode(_ request: SessionRequest) throws -> Data {
+        let dict: [String: Any]
+        switch request {
+        case .exec(let cmd, let timeout, let env):
+            dict = ["type": "exec", "cmd": cmd, "timeout": timeout, "env": env]
+        case .upload(let localPath, let remotePath):
+            dict = ["type": "upload", "local_path": localPath, "remote_path": remotePath]
+        case .download(let remotePath, let localPath):
+            dict = ["type": "download", "remote_path": remotePath, "local_path": localPath]
+        case .shutdown:
+            dict = ["type": "shutdown"]
+        }
+        var data = try JSONSerialization.data(withJSONObject: dict, options: [.sortedKeys])
+        data.append(contentsOf: [UInt8(ascii: "\n")])
+        return data
+    }
+
+    public static func encode(_ response: SessionResponse) throws -> Data {
+        let dict: [String: Any]
+        switch response {
+        case .output(let stream, let data):
+            dict = ["type": "output", "stream": stream.rawValue, "data": data]
+        case .exit(let code, let durationMs):
+            dict = ["type": "exit", "code": Int(code), "duration_ms": durationMs]
+        case .error(let message):
+            dict = ["type": "error", "message": message]
+        case .uploadDone(let path):
+            dict = ["type": "upload_done", "path": path]
+        case .downloadDone(let path):
+            dict = ["type": "download_done", "path": path]
+        }
+        var data = try JSONSerialization.data(withJSONObject: dict, options: [.sortedKeys])
+        data.append(contentsOf: [UInt8(ascii: "\n")])
+        return data
+    }
+
+    public static func decodeRequest(_ data: Data) throws -> SessionRequest {
+        let trimmed = data.prefix(while: { $0 != UInt8(ascii: "\n") })
+        guard let json = try? JSONSerialization.jsonObject(with: trimmed) as? [String: Any],
+              let type = json["type"] as? String
+        else {
+            throw LuminaError.protocolError("Invalid JSON in session request")
+        }
+
+        switch type {
+        case "exec":
+            guard let cmd = json["cmd"] as? String,
+                  let timeout = json["timeout"] as? Int else {
+                throw LuminaError.protocolError("Malformed exec request")
+            }
+            let env = json["env"] as? [String: String] ?? [:]
+            return .exec(cmd: cmd, timeout: timeout, env: env)
+        case "upload":
+            guard let localPath = json["local_path"] as? String,
+                  let remotePath = json["remote_path"] as? String else {
+                throw LuminaError.protocolError("Malformed upload request")
+            }
+            return .upload(localPath: localPath, remotePath: remotePath)
+        case "download":
+            guard let remotePath = json["remote_path"] as? String,
+                  let localPath = json["local_path"] as? String else {
+                throw LuminaError.protocolError("Malformed download request")
+            }
+            return .download(remotePath: remotePath, localPath: localPath)
+        case "shutdown":
+            return .shutdown
+        default:
+            throw LuminaError.protocolError("Unknown session request type: \(type)")
+        }
+    }
+
+    public static func decodeResponse(_ data: Data) throws -> SessionResponse {
+        let trimmed = data.prefix(while: { $0 != UInt8(ascii: "\n") })
+        guard let json = try? JSONSerialization.jsonObject(with: trimmed) as? [String: Any],
+              let type = json["type"] as? String
+        else {
+            throw LuminaError.protocolError("Invalid JSON in session response")
+        }
+
+        switch type {
+        case "output":
+            guard let streamStr = json["stream"] as? String,
+                  let stream = OutputStream(rawValue: streamStr),
+                  let data = json["data"] as? String else {
+                throw LuminaError.protocolError("Malformed output response")
+            }
+            return .output(stream: stream, data: data)
+        case "exit":
+            guard let code = json["code"] as? Int,
+                  let durationMs = json["duration_ms"] as? Int else {
+                throw LuminaError.protocolError("Malformed exit response")
+            }
+            return .exit(code: Int32(code), durationMs: durationMs)
+        case "error":
+            guard let message = json["message"] as? String else {
+                throw LuminaError.protocolError("Malformed error response")
+            }
+            return .error(message: message)
+        case "upload_done":
+            guard let path = json["path"] as? String else {
+                throw LuminaError.protocolError("Malformed upload_done response")
+            }
+            return .uploadDone(path: path)
+        case "download_done":
+            guard let path = json["path"] as? String else {
+                throw LuminaError.protocolError("Malformed download_done response")
+            }
+            return .downloadDone(path: path)
+        default:
+            throw LuminaError.protocolError("Unknown session response type: \(type)")
+        }
+    }
+}

--- a/Sources/Lumina/SessionServer.swift
+++ b/Sources/Lumina/SessionServer.swift
@@ -1,0 +1,198 @@
+// Sources/Lumina/SessionServer.swift
+import Foundation
+
+/// Listens on a Unix domain socket and dispatches SessionRequest messages
+/// to a VM actor. Each accepted connection is served sequentially -- one
+/// client at a time (the CLI client connects, sends a request, gets a
+/// response, disconnects).
+public final class SessionServer: @unchecked Sendable {
+    private let socketPath: URL
+    private var serverFd: Int32 = -1
+    private let lock = NSLock()
+
+    public init(socketPath: URL) {
+        self.socketPath = socketPath
+    }
+
+    /// Bind and listen on the Unix domain socket.
+    public func bind() throws {
+        // Remove stale socket file
+        try? FileManager.default.removeItem(at: socketPath)
+
+        serverFd = socket(AF_UNIX, SOCK_STREAM, 0)
+        guard serverFd >= 0 else {
+            throw LuminaError.sessionFailed("Failed to create socket: \(errno)")
+        }
+
+        var addr = sockaddr_un()
+        addr.sun_family = sa_family_t(AF_UNIX)
+        let path = socketPath.path
+        let pathBytes = path.utf8CString
+        withUnsafeMutablePointer(to: &addr.sun_path) { ptr in
+            ptr.withMemoryRebound(to: CChar.self, capacity: 104) { dest in
+                pathBytes.withUnsafeBufferPointer { src in
+                    let count = min(src.count, 104)
+                    dest.update(from: src.baseAddress!, count: count)
+                }
+            }
+        }
+
+        let bindResult = withUnsafePointer(to: &addr) { ptr in
+            ptr.withMemoryRebound(to: sockaddr.self, capacity: 1) { sockPtr in
+                Darwin.bind(serverFd, sockPtr, socklen_t(MemoryLayout<sockaddr_un>.size))
+            }
+        }
+        guard bindResult == 0 else {
+            Darwin.close(serverFd)
+            serverFd = -1
+            throw LuminaError.sessionFailed("Failed to bind socket: \(errno)")
+        }
+
+        guard listen(serverFd, 5) == 0 else {
+            Darwin.close(serverFd)
+            serverFd = -1
+            throw LuminaError.sessionFailed("Failed to listen on socket: \(errno)")
+        }
+    }
+
+    /// Accept a client connection. Blocks until a client connects.
+    /// Returns file handles for reading and writing.
+    public func accept() throws -> (read: FileHandle, write: FileHandle) {
+        let clientFd = Darwin.accept(serverFd, nil, nil)
+        guard clientFd >= 0 else {
+            throw LuminaError.sessionFailed("Failed to accept connection: \(errno)")
+        }
+        return (
+            read: FileHandle(fileDescriptor: clientFd, closeOnDealloc: false),
+            write: FileHandle(fileDescriptor: clientFd, closeOnDealloc: false)
+        )
+    }
+
+    /// Read one NDJSON line from a file handle.
+    public func readMessage(from handle: FileHandle) throws -> Data {
+        var buffer = Data()
+        while true {
+            let chunk = handle.availableData
+            if chunk.isEmpty {
+                if buffer.isEmpty { throw LuminaError.connectionFailed }
+                return buffer
+            }
+            buffer.append(chunk)
+            if buffer.count > SessionProtocol.maxMessageSize {
+                throw LuminaError.protocolError("Session message exceeds 64KB")
+            }
+            if buffer.firstIndex(of: UInt8(ascii: "\n")) != nil {
+                return buffer
+            }
+        }
+    }
+
+    /// Write a SessionResponse to the client.
+    public func writeResponse(_ response: SessionResponse, to handle: FileHandle) throws {
+        let data = try SessionProtocol.encode(response)
+        handle.write(data)
+    }
+
+    /// Close the server socket.
+    public func close() {
+        if serverFd >= 0 {
+            Darwin.close(serverFd)
+            serverFd = -1
+        }
+        try? FileManager.default.removeItem(at: socketPath)
+    }
+
+    /// Run the server loop: accept connections, dispatch requests to the VM.
+    /// This blocks indefinitely until the server is closed or a shutdown request arrives.
+    public func serve(vm: VM) async {
+        while serverFd >= 0 {
+            let handles: (read: FileHandle, write: FileHandle)
+            do {
+                handles = try accept()
+            } catch {
+                if serverFd < 0 { break } // server was closed
+                continue
+            }
+
+            let clientFd = handles.read.fileDescriptor
+            defer { Darwin.close(clientFd) }
+
+            // Read and dispatch messages until client disconnects
+            while true {
+                let msgData: Data
+                do {
+                    msgData = try readMessage(from: handles.read)
+                } catch {
+                    break // client disconnected
+                }
+
+                let request: SessionRequest
+                do {
+                    request = try SessionProtocol.decodeRequest(msgData)
+                } catch {
+                    try? writeResponse(.error(message: "Invalid request: \(error)"), to: handles.write)
+                    break
+                }
+
+                switch request {
+                case .exec(let cmd, let timeout, let env):
+                    await handleExec(cmd: cmd, timeout: timeout, env: env, vm: vm, handle: handles.write)
+
+                case .upload(let localPath, let remotePath):
+                    await handleUpload(localPath: localPath, remotePath: remotePath, vm: vm, handle: handles.write)
+
+                case .download(let remotePath, let localPath):
+                    await handleDownload(remotePath: remotePath, localPath: localPath, vm: vm, handle: handles.write)
+
+                case .shutdown:
+                    await vm.shutdown()
+                    try? writeResponse(.exit(code: 0, durationMs: 0), to: handles.write)
+                    close()
+                    return
+                }
+            }
+        }
+    }
+
+    // MARK: - Request Handlers
+
+    private func handleExec(cmd: String, timeout: Int, env: [String: String], vm: VM, handle: FileHandle) async {
+        let start = ContinuousClock.now
+        let result = await vm.execResult(cmd, timeout: timeout, env: env)
+        let ms = Int((ContinuousClock.now - start).components.seconds * 1000)
+        switch result {
+        case .success(let runResult):
+            if !runResult.stdout.isEmpty {
+                try? writeResponse(.output(stream: .stdout, data: runResult.stdout), to: handle)
+            }
+            if !runResult.stderr.isEmpty {
+                try? writeResponse(.output(stream: .stderr, data: runResult.stderr), to: handle)
+            }
+            try? writeResponse(.exit(code: runResult.exitCode, durationMs: ms), to: handle)
+        case .failure(let error):
+            try? writeResponse(.error(message: String(describing: error)), to: handle)
+        }
+    }
+
+    private func handleUpload(localPath: String, remotePath: String, vm: VM, handle: FileHandle) async {
+        let upload = FileUpload(localPath: URL(fileURLWithPath: localPath), remotePath: remotePath)
+        let result = await vm.uploadFilesResult([upload])
+        switch result {
+        case .success:
+            try? writeResponse(.uploadDone(path: remotePath), to: handle)
+        case .failure(let error):
+            try? writeResponse(.error(message: "Upload failed: \(error)"), to: handle)
+        }
+    }
+
+    private func handleDownload(remotePath: String, localPath: String, vm: VM, handle: FileHandle) async {
+        let download = FileDownload(remotePath: remotePath, localPath: URL(fileURLWithPath: localPath))
+        let result = await vm.downloadFilesResult([download])
+        switch result {
+        case .success:
+            try? writeResponse(.downloadDone(path: localPath), to: handle)
+        case .failure(let error):
+            try? writeResponse(.error(message: "Download failed: \(error)"), to: handle)
+        }
+    }
+}

--- a/Sources/Lumina/Types.swift
+++ b/Sources/Lumina/Types.swift
@@ -80,6 +80,9 @@ public struct VMOptions: Sendable {
     public var image: String
     public var networkProvider: any NetworkProvider
     public var mounts: [MountPoint]
+    public var privateNetworkFd: Int32?  // Raw fd, not FileHandle (FileHandle isn't Sendable)
+    public var networkHosts: [String: String]?
+    public var networkIP: String?
 
     public static let `default` = VMOptions()
 
@@ -88,13 +91,19 @@ public struct VMOptions: Sendable {
         cpuCount: Int = 2,
         image: String = "default",
         networkProvider: any NetworkProvider = NATNetworkProvider(),
-        mounts: [MountPoint] = []
+        mounts: [MountPoint] = [],
+        privateNetworkFd: Int32? = nil,
+        networkHosts: [String: String]? = nil,
+        networkIP: String? = nil
     ) {
         self.memory = memory
         self.cpuCount = cpuCount
         self.image = image
         self.networkProvider = networkProvider
         self.mounts = mounts
+        self.privateNetworkFd = privateNetworkFd
+        self.networkHosts = networkHosts
+        self.networkIP = networkIP
     }
 
     public init(from runOptions: RunOptions) {
@@ -103,6 +112,9 @@ public struct VMOptions: Sendable {
         self.image = runOptions.image
         self.networkProvider = NATNetworkProvider()
         self.mounts = runOptions.mounts
+        self.privateNetworkFd = nil
+        self.networkHosts = nil
+        self.networkIP = nil
     }
 }
 

--- a/Sources/Lumina/Types.swift
+++ b/Sources/Lumina/Types.swift
@@ -212,6 +212,28 @@ public struct VolumeMount: Sendable {
     }
 }
 
+// MARK: - Image Types
+
+public struct ImageInfo: Sendable {
+    public let name: String
+    public let base: String?
+    public let command: String?
+    public let created: Date
+    public let sizeBytes: UInt64
+}
+
+public struct ImageMeta: Sendable, Codable {
+    public let base: String?
+    public let command: String?
+    public let created: Date
+
+    public init(base: String?, command: String?, created: Date) {
+        self.base = base
+        self.command = command
+        self.created = created
+    }
+}
+
 // MARK: - Errors
 
 public enum LuminaError: Error, Sendable {

--- a/Sources/Lumina/Types.swift
+++ b/Sources/Lumina/Types.swift
@@ -142,6 +142,76 @@ public enum VMState: Sendable, Equatable {
     case shutdown
 }
 
+// MARK: - Session Types
+
+public struct SessionOptions: Sendable {
+    public var cpuCount: Int
+    public var memory: UInt64
+    public var image: String
+    public var timeout: Duration
+    public var env: [String: String]
+    public var volumes: [VolumeMount]
+
+    public init(
+        cpuCount: Int = 2,
+        memory: UInt64 = 512 * 1024 * 1024,
+        image: String = "default",
+        timeout: Duration = .seconds(60),
+        env: [String: String] = [:],
+        volumes: [VolumeMount] = []
+    ) {
+        self.cpuCount = cpuCount
+        self.memory = memory
+        self.image = image
+        self.timeout = timeout
+        self.env = env
+        self.volumes = volumes
+    }
+}
+
+public struct SessionInfo: Sendable, Codable {
+    public let sid: String
+    public let pid: Int32
+    public let image: String
+    public let cpuCount: Int
+    public let memory: UInt64
+    public let created: Date
+    public var status: SessionState
+
+    public init(
+        sid: String,
+        pid: Int32,
+        image: String,
+        cpuCount: Int,
+        memory: UInt64,
+        created: Date,
+        status: SessionState
+    ) {
+        self.sid = sid
+        self.pid = pid
+        self.image = image
+        self.cpuCount = cpuCount
+        self.memory = memory
+        self.created = created
+        self.status = status
+    }
+}
+
+public enum SessionState: String, Sendable, Codable, Equatable {
+    case running
+    case dead
+}
+
+public struct VolumeMount: Sendable {
+    public let name: String
+    public let guestPath: String
+
+    public init(name: String, guestPath: String) {
+        self.name = name
+        self.guestPath = guestPath
+    }
+}
+
 // MARK: - Errors
 
 public enum LuminaError: Error, Sendable {
@@ -154,6 +224,9 @@ public enum LuminaError: Error, Sendable {
     case protocolError(String)
     case uploadFailed(path: String, reason: String)
     case downloadFailed(path: String, reason: String)
+    case sessionNotFound(String)
+    case sessionDead(String)
+    case sessionFailed(String)
 }
 
 // MARK: - Parsing Helpers

--- a/Sources/Lumina/VM.swift
+++ b/Sources/Lumina/VM.swift
@@ -243,7 +243,7 @@ public actor VM {
     // custom-executor actor back to the caller. Catching inside the actor and
     // returning Result preserves the type as a value.
 
-    func bootResult() async -> Result<Void, LuminaError> {
+    public func bootResult() async -> Result<Void, LuminaError> {
         do {
             try await boot()
             return .success(())

--- a/Sources/Lumina/VM.swift
+++ b/Sources/Lumina/VM.swift
@@ -93,6 +93,15 @@ public actor VM {
                 modulesDir: imagePaths.modulesDir,
                 outputURL: combinedInitrd
             )
+            // Append network overlay if private networking is configured
+            if let hosts = options.networkHosts, let ip = options.networkIP {
+                try InitrdPatcher.appendNetworkOverlay(
+                    initrdURL: combinedInitrd,
+                    hosts: hosts,
+                    ip: ip
+                )
+            }
+
             bootLoader.initialRamdiskURL = combinedInitrd
         } else {
             bootLoader.initialRamdiskURL = imagePaths.initrd
@@ -105,6 +114,9 @@ public actor VM {
         if !options.mounts.isEmpty {
             let specs = options.mounts.enumerated().map { "lumina\($0.offset):\($0.element.guestPath)" }
             cmdLine += " lumina_mounts=\(specs.joined(separator: ","))"
+        }
+        if let ip = options.networkIP {
+            cmdLine += " lumina_ip=\(ip)"
         }
         bootLoader.commandLine = cmdLine
         config.bootLoader = bootLoader
@@ -154,7 +166,17 @@ public actor VM {
             _state = .idle
             throw .bootFailed(underlying: error)
         }
-        config.networkDevices = [networkDevice]
+        var networkDevices: [VZVirtioNetworkDeviceConfiguration] = [networkDevice]
+
+        // Private network interface (eth1) for VM-to-VM networking
+        if let netFd = options.privateNetworkFd {
+            let privateNet = VZVirtioNetworkDeviceConfiguration()
+            // Create FileHandle from raw fd here on the actor's executor (FileHandle isn't Sendable)
+            let netHandle = FileHandle(fileDescriptor: netFd, closeOnDealloc: false)
+            privateNet.attachment = VZFileHandleNetworkDeviceAttachment(fileHandle: netHandle)
+            networkDevices.append(privateNet)
+        }
+        config.networkDevices = networkDevices
 
         // vsock
         let vsockDevice = VZVirtioSocketDeviceConfiguration()

--- a/Sources/Lumina/VM.swift
+++ b/Sources/Lumina/VM.swift
@@ -46,6 +46,9 @@ public actor VM {
 
     public var state: VMState { _state }
 
+    /// Expose the current disk clone for image creation workflows.
+    public var diskClone: DiskClone? { clone }
+
     public init(options: VMOptions = .default) {
         self.options = options
         self.imageStore = ImageStore()

--- a/Sources/Lumina/VolumeStore.swift
+++ b/Sources/Lumina/VolumeStore.swift
@@ -1,0 +1,7 @@
+// Sources/Lumina/VolumeStore.swift (stub -- full implementation in Task 7)
+import Foundation
+
+public struct VolumeStore: Sendable {
+    public init() {}
+    public func resolve(name: String) -> URL? { nil }
+}

--- a/Sources/Lumina/VolumeStore.swift
+++ b/Sources/Lumina/VolumeStore.swift
@@ -1,7 +1,108 @@
-// Sources/Lumina/VolumeStore.swift (stub -- full implementation in Task 7)
+// Sources/Lumina/VolumeStore.swift
 import Foundation
 
+public struct VolumeInfo: Sendable {
+    public let name: String
+    public let created: Date
+    public let lastUsed: Date
+    public let sizeBytes: UInt64
+}
+
+struct VolumeMeta: Codable {
+    var created: Date
+    var lastUsed: Date
+}
+
 public struct VolumeStore: Sendable {
-    public init() {}
-    public func resolve(name: String) -> URL? { nil }
+    public let baseDir: URL
+
+    public static let defaultBaseDir: URL = {
+        FileManager.default.homeDirectoryForCurrentUser
+            .appendingPathComponent(".lumina/volumes")
+    }()
+
+    public init(baseDir: URL = VolumeStore.defaultBaseDir) {
+        self.baseDir = baseDir
+    }
+
+    public func create(name: String) throws {
+        let dir = baseDir.appendingPathComponent(name)
+        let dataDir = dir.appendingPathComponent("data")
+        try FileManager.default.createDirectory(at: dataDir, withIntermediateDirectories: true)
+
+        let meta = VolumeMeta(created: Date(), lastUsed: Date())
+        let data = try JSONEncoder().encode(meta)
+        try data.write(to: dir.appendingPathComponent("meta.json"))
+    }
+
+    public func resolve(name: String) -> URL? {
+        let dataDir = baseDir.appendingPathComponent(name).appendingPathComponent("data")
+        var isDir: ObjCBool = false
+        guard FileManager.default.fileExists(atPath: dataDir.path, isDirectory: &isDir),
+              isDir.boolValue else {
+            return nil
+        }
+        return dataDir
+    }
+
+    public func remove(name: String) throws {
+        let dir = baseDir.appendingPathComponent(name)
+        try FileManager.default.removeItem(at: dir)
+    }
+
+    public func list() -> [String] {
+        guard let entries = try? FileManager.default.contentsOfDirectory(
+            at: baseDir,
+            includingPropertiesForKeys: [.isDirectoryKey]
+        ) else { return [] }
+        return entries
+            .filter { (try? $0.resourceValues(forKeys: [.isDirectoryKey]).isDirectory) == true }
+            .map { $0.lastPathComponent }
+            .sorted()
+    }
+
+    public func inspect(name: String) throws -> VolumeInfo {
+        let dir = baseDir.appendingPathComponent(name)
+        let metaFile = dir.appendingPathComponent("meta.json")
+
+        guard FileManager.default.fileExists(atPath: dir.path) else {
+            throw LuminaError.sessionFailed("Volume '\(name)' not found")
+        }
+
+        var created = Date()
+        var lastUsed = Date()
+        if let data = try? Data(contentsOf: metaFile),
+           let meta = try? JSONDecoder().decode(VolumeMeta.self, from: data) {
+            created = meta.created
+            lastUsed = meta.lastUsed
+        }
+
+        let dataDir = dir.appendingPathComponent("data")
+        let size = directorySize(dataDir)
+
+        return VolumeInfo(name: name, created: created, lastUsed: lastUsed, sizeBytes: size)
+    }
+
+    /// Update last_used timestamp when a volume is mounted.
+    public func touch(name: String) {
+        let metaFile = baseDir.appendingPathComponent(name).appendingPathComponent("meta.json")
+        guard let data = try? Data(contentsOf: metaFile),
+              var meta = try? JSONDecoder().decode(VolumeMeta.self, from: data) else { return }
+        meta.lastUsed = Date()
+        if let updated = try? JSONEncoder().encode(meta) {
+            try? updated.write(to: metaFile)
+        }
+    }
+
+    private func directorySize(_ url: URL) -> UInt64 {
+        let fm = FileManager.default
+        guard let enumerator = fm.enumerator(at: url, includingPropertiesForKeys: [.fileSizeKey]) else { return 0 }
+        var total: UInt64 = 0
+        for case let fileURL as URL in enumerator {
+            if let size = try? fileURL.resourceValues(forKeys: [.fileSizeKey]).fileSize {
+                total += UInt64(size)
+            }
+        }
+        return total
+    }
 }

--- a/Sources/lumina-cli/CLI.swift
+++ b/Sources/lumina-cli/CLI.swift
@@ -334,8 +334,16 @@ struct Pull: AsyncParsableCommand {
 
 // MARK: - Images
 
-struct Images: ParsableCommand {
-    static let configuration = CommandConfiguration(abstract: "List cached images")
+struct Images: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(
+        abstract: "Manage cached images",
+        subcommands: [ImageList.self, ImageCreate.self, ImageRemove.self, ImageInspect.self],
+        defaultSubcommand: ImageList.self
+    )
+}
+
+struct ImageList: ParsableCommand {
+    static let configuration = CommandConfiguration(commandName: "list", abstract: "List cached images")
 
     func run() throws {
         let store = ImageStore()
@@ -344,6 +352,71 @@ struct Images: ParsableCommand {
             print("No images found. Run 'lumina pull' first.")
         } else {
             for name in names { print(name) }
+        }
+    }
+}
+
+struct ImageCreate: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(commandName: "create", abstract: "Create a custom image")
+
+    @Argument(help: "Name for the new image")
+    var name: String
+
+    @Option(name: .long, help: "Base image to build from")
+    var from: String = "default"
+
+    @Option(name: [.customLong("run")], help: "Command to run for setup")
+    var buildCommand: String
+
+    func run() async throws {
+        FileHandle.standardError.write(Data("Creating image '\(name)' from '\(from)'...\n".utf8))
+        do {
+            try await Lumina.createImage(name: name, from: from, command: buildCommand)
+            print("Image '\(name)' created successfully.")
+        } catch {
+            FileHandle.standardError.write(Data("lumina: image create failed: \(error)\n".utf8))
+            throw ExitCode.failure
+        }
+    }
+}
+
+struct ImageRemove: ParsableCommand {
+    static let configuration = CommandConfiguration(commandName: "remove", abstract: "Remove a cached image")
+
+    @Argument(help: "Image name to remove")
+    var name: String
+
+    func run() throws {
+        let store = ImageStore()
+        do {
+            try store.removeImage(name: name)
+            print("Image '\(name)' removed.")
+        } catch {
+            FileHandle.standardError.write(Data("lumina: \(error)\n".utf8))
+            throw ExitCode.failure
+        }
+    }
+}
+
+struct ImageInspect: ParsableCommand {
+    static let configuration = CommandConfiguration(commandName: "inspect", abstract: "Show image details")
+
+    @Argument(help: "Image name")
+    var name: String
+
+    func run() throws {
+        let store = ImageStore()
+        let info = try store.inspect(name: name)
+        let dict: [String: Any] = [
+            "name": info.name,
+            "base": info.base ?? "none",
+            "command": info.command ?? "none",
+            "size_bytes": info.sizeBytes,
+            "created": ISO8601DateFormatter().string(from: info.created)
+        ]
+        if let data = try? JSONSerialization.data(withJSONObject: dict, options: [.sortedKeys, .prettyPrinted]),
+           let str = String(data: data, encoding: .utf8) {
+            print(str)
         }
     }
 }

--- a/Sources/lumina-cli/CLI.swift
+++ b/Sources/lumina-cli/CLI.swift
@@ -10,7 +10,7 @@ struct LuminaCLI: AsyncParsableCommand {
         abstract: "Native Apple Workload Runtime for Agents — subprocess.run() for virtual machines.",
         version: "0.2.2",
         subcommands: [Run.self, Pull.self, Images.self, Clean.self,
-                      Session.self, Exec.self, SessionServe.self]
+                      Session.self, Exec.self, SessionServe.self, Volume.self]
     )
 }
 
@@ -48,6 +48,9 @@ struct Run: AsyncParsableCommand {
 
     @Option(name: .long, help: "Mount host directory into VM (host:guest, repeatable)")
     var mount: [String] = []
+
+    @Option(name: .long, help: "Mount named volume (name:guest_path, repeatable)")
+    var volume: [String] = []
 
     func run() async throws {
         installSignalHandlers()
@@ -139,6 +142,23 @@ struct Run: AsyncParsableCommand {
                 throw ExitCode.failure
             }
             parsedMounts.append(MountPoint(hostPath: hostURL, guestPath: guest))
+        }
+
+        // Resolve --volume flags (name:guest_path -> host_path:guest_path)
+        let volumeStore = VolumeStore()
+        for spec in volume {
+            guard let colonIndex = spec.firstIndex(of: ":") else {
+                FileHandle.standardError.write(Data("lumina: invalid --volume '\(spec)'. Use name:guest_path\n".utf8))
+                throw ExitCode.failure
+            }
+            let name = String(spec[..<colonIndex])
+            let guestPath = String(spec[spec.index(after: colonIndex)...])
+            guard let hostDir = volumeStore.resolve(name: name) else {
+                FileHandle.standardError.write(Data("lumina: volume '\(name)' not found\n".utf8))
+                throw ExitCode.failure
+            }
+            volumeStore.touch(name: name)
+            parsedMounts.append(MountPoint(hostPath: hostDir, guestPath: guestPath))
         }
 
         let options = RunOptions(
@@ -728,6 +748,77 @@ struct Exec: AsyncParsableCommand {
             default:
                 continue
             }
+        }
+    }
+}
+
+// MARK: - Volume
+
+struct Volume: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(
+        abstract: "Manage persistent volumes",
+        subcommands: [VolumeCreate.self, VolumeList.self, VolumeRemove.self, VolumeInspect.self]
+    )
+}
+
+struct VolumeCreate: ParsableCommand {
+    static let configuration = CommandConfiguration(commandName: "create", abstract: "Create a named volume")
+
+    @Argument(help: "Volume name")
+    var name: String
+
+    func run() throws {
+        let store = VolumeStore()
+        try store.create(name: name)
+        print("Volume '\(name)' created.")
+    }
+}
+
+struct VolumeList: ParsableCommand {
+    static let configuration = CommandConfiguration(commandName: "list", abstract: "List volumes")
+
+    func run() throws {
+        let store = VolumeStore()
+        let names = store.list()
+        if names.isEmpty {
+            print("No volumes.")
+        } else {
+            for name in names { print(name) }
+        }
+    }
+}
+
+struct VolumeRemove: ParsableCommand {
+    static let configuration = CommandConfiguration(commandName: "remove", abstract: "Remove a volume")
+
+    @Argument(help: "Volume name")
+    var name: String
+
+    func run() throws {
+        let store = VolumeStore()
+        try store.remove(name: name)
+        print("Volume '\(name)' removed.")
+    }
+}
+
+struct VolumeInspect: ParsableCommand {
+    static let configuration = CommandConfiguration(commandName: "inspect", abstract: "Show volume details")
+
+    @Argument(help: "Volume name")
+    var name: String
+
+    func run() throws {
+        let store = VolumeStore()
+        let info = try store.inspect(name: name)
+        let dict: [String: Any] = [
+            "name": info.name,
+            "size_bytes": info.sizeBytes,
+            "created": ISO8601DateFormatter().string(from: info.created),
+            "last_used": ISO8601DateFormatter().string(from: info.lastUsed)
+        ]
+        if let data = try? JSONSerialization.data(withJSONObject: dict, options: [.sortedKeys, .prettyPrinted]),
+           let str = String(data: data, encoding: .utf8) {
+            print(str)
         }
     }
 }

--- a/Sources/lumina-cli/CLI.swift
+++ b/Sources/lumina-cli/CLI.swift
@@ -10,7 +10,8 @@ struct LuminaCLI: AsyncParsableCommand {
         abstract: "Native Apple Workload Runtime for Agents — subprocess.run() for virtual machines.",
         version: "0.2.2",
         subcommands: [Run.self, Pull.self, Images.self, Clean.self,
-                      Session.self, Exec.self, SessionServe.self, Volume.self]
+                      Session.self, Exec.self, SessionServe.self,
+                      Volume.self, NetworkCmd.self]
     )
 }
 
@@ -821,6 +822,70 @@ struct VolumeInspect: ParsableCommand {
             print(str)
         }
     }
+}
+
+// MARK: - Network
+
+struct NetworkCmd: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "network",
+        abstract: "Run a group of VMs on a shared network",
+        subcommands: [NetworkRun.self]
+    )
+}
+
+struct NetworkRun: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(commandName: "run", abstract: "Run VMs from a manifest file")
+
+    @Option(name: .long, help: "Path to network manifest JSON file")
+    var file: String
+
+    func run() async throws {
+        installSignalHandlers()
+        atexit { DiskClone.cleanOrphans() }
+
+        let fileURL = URL(fileURLWithPath: file)
+        guard FileManager.default.fileExists(atPath: fileURL.path) else {
+            FileHandle.standardError.write(Data("lumina: manifest file not found: \(file)\n".utf8))
+            throw ExitCode.failure
+        }
+
+        let data = try Data(contentsOf: fileURL)
+        let manifest: NetworkManifest
+        do {
+            manifest = try JSONDecoder().decode(NetworkManifest.self, from: data)
+        } catch {
+            FileHandle.standardError.write(Data("lumina: invalid manifest: \(error)\n".utf8))
+            throw ExitCode.failure
+        }
+
+        FileHandle.standardError.write(Data("Starting \(manifest.sessions.count) sessions on shared network...\n".utf8))
+
+        try await Lumina.withNetwork("cli") { network in
+            for session in manifest.sessions {
+                FileHandle.standardError.write(Data("  Booting '\(session.name)' (image: \(session.image ?? "default"))...\n".utf8))
+                _ = try await network.session(
+                    name: session.name,
+                    image: session.image ?? "default"
+                )
+            }
+            FileHandle.standardError.write(Data("All sessions running. Press Ctrl-C to tear down.\n".utf8))
+
+            // Block main thread until signal — dispatchMain() never returns,
+            // signal handler triggers exit, withNetwork scope ensures shutdown
+            dispatchMain()
+        }
+    }
+}
+
+struct NetworkManifest: Codable {
+    let sessions: [NetworkSession]
+}
+
+struct NetworkSession: Codable {
+    let name: String
+    let image: String?
+    let volumes: [String]?
 }
 
 // Parsing helpers (parseDuration, parseMemory) are in Lumina/Types.swift

--- a/Sources/lumina-cli/CLI.swift
+++ b/Sources/lumina-cli/CLI.swift
@@ -1,63 +1,7 @@
-// Sources/lumina-cli/main.swift
+// Sources/lumina-cli/CLI.swift
 import ArgumentParser
 import Foundation
 import Lumina
-
-// Install signal handlers via sigaction. sigaction is stronger than signal() —
-// it can't be silently overridden. The handler cleans orphaned COW clones, then
-// re-raises the signal with default disposition so the parent process gets the
-// correct wait status (128 + signal).
-private func installSignalHandlers() {
-    for sig: Int32 in [SIGINT, SIGTERM] {
-        var action = sigaction()
-        action.__sigaction_u.__sa_handler = { signum in
-            let pid = "\(getpid())"
-            let runsDir = DiskClone.defaultRunsDir
-            if let entries = try? FileManager.default.contentsOfDirectory(
-                at: runsDir, includingPropertiesForKeys: nil
-            ) {
-                for entry in entries {
-                    let pidFile = entry.appendingPathComponent(".pid")
-                    if let content = try? String(contentsOf: pidFile, encoding: .utf8),
-                       content.trimmingCharacters(in: .whitespacesAndNewlines) == pid {
-                        try? FileManager.default.removeItem(at: entry)
-                    }
-                }
-            }
-            signal(signum, SIG_DFL)
-            raise(signum)
-        }
-        sigemptyset(&action.sa_mask)
-        action.sa_flags = 0
-        sigaction(sig, &action, nil)
-    }
-}
-
-// MARK: - Output Format
-
-/// Determine output format: JSON (for agents/pipes) or text (for humans/TTYs).
-/// Priority: LUMINA_FORMAT env > --text flag > isatty() auto-detection.
-private enum OutputFormat {
-    case json
-    case text
-}
-
-private func resolveOutputFormat(textFlag: Bool) -> OutputFormat {
-    // 1. LUMINA_FORMAT env var takes highest priority
-    if let envFormat = ProcessInfo.processInfo.environment["LUMINA_FORMAT"]?.lowercased() {
-        switch envFormat {
-        case "json": return .json
-        case "text", "human": return .text
-        default: break
-        }
-    }
-
-    // 2. --text flag explicitly requests human-readable
-    if textFlag { return .text }
-
-    // 3. Auto-detect: TTY → text, pipe → JSON
-    return isatty(STDOUT_FILENO) != 0 ? .text : .json
-}
 
 @main
 struct LuminaCLI: AsyncParsableCommand {
@@ -65,7 +9,8 @@ struct LuminaCLI: AsyncParsableCommand {
         commandName: "lumina",
         abstract: "Native Apple Workload Runtime for Agents — subprocess.run() for virtual machines.",
         version: "0.2.2",
-        subcommands: [Run.self, Pull.self, Images.self, Clean.self]
+        subcommands: [Run.self, Pull.self, Images.self, Clean.self,
+                      Session.self, Exec.self, SessionServe.self]
     )
 }
 
@@ -341,20 +286,6 @@ private func printErrorJSON(_ error: any Error, durationMs: Int) {
     encodeAndPrint(r)
 }
 
-/// Print an NDJSON line (used for streaming output).
-private func printNDJSON(_ dict: [String: Any]) {
-    // Use JSONSerialization for heterogeneous dicts, then ensure no literal newlines
-    guard let data = try? JSONSerialization.data(withJSONObject: dict, options: [.sortedKeys, .fragmentsAllowed]),
-          var str = String(data: data, encoding: .utf8) else { return }
-    // JSONSerialization doesn't escape newlines in string values — replace them
-    str = str.replacingOccurrences(of: "\n", with: "\\n")
-    str = str.replacingOccurrences(of: "\r", with: "\\r")
-    str = str.replacingOccurrences(of: "\t", with: "\\t")
-    print(str)
-    // Flush stdout for real-time streaming
-    fflush(stdout)
-}
-
 private func encodeAndPrint<T: Encodable>(_ value: T) {
     let encoder = JSONEncoder()
     encoder.outputFormatting = .sortedKeys
@@ -428,6 +359,302 @@ struct Clean: ParsableCommand {
             print("Removed \(removed) orphaned clone(s).")
         } else {
             print("No orphaned clones found.")
+        }
+    }
+}
+
+// MARK: - Session
+
+struct Session: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(
+        abstract: "Manage persistent VM sessions",
+        subcommands: [SessionStart.self, SessionStop.self, SessionList.self]
+    )
+}
+
+struct SessionStart: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(commandName: "start", abstract: "Start a new persistent session")
+
+    @Option(name: .long, help: "Image to boot from")
+    var image: String = "default"
+
+    @Option(name: .long, help: "Number of CPU cores")
+    var cpus: Int = 2
+
+    @Option(name: .long, help: "Memory (e.g. 512MB, 1GB)")
+    var memory: String = "512MB"
+
+    @Option(name: .long, help: "Volume to mount (name:guest_path, repeatable)")
+    var volume: [String] = []
+
+    func run() async throws {
+        // Auto-pull image if not present
+        let puller = ImagePuller()
+        if !puller.imageExists() {
+            FileHandle.standardError.write(Data("Image not found. Pulling default image...\n".utf8))
+            do {
+                try await puller.pull { msg in
+                    FileHandle.standardError.write(Data("\(msg)\n".utf8))
+                }
+            } catch {
+                FileHandle.standardError.write(Data("lumina: auto-pull failed: \(error)\n".utf8))
+                throw ExitCode.failure
+            }
+        }
+
+        guard let parsedMemory = parseMemory(memory) else {
+            FileHandle.standardError.write(Data("lumina: invalid memory '\(memory)'\n".utf8))
+            throw ExitCode.failure
+        }
+
+        var parsedVolumes: [VolumeMount] = []
+        for spec in volume {
+            guard let colonIndex = spec.firstIndex(of: ":") else {
+                FileHandle.standardError.write(Data("lumina: invalid --volume '\(spec)'. Use name:guest_path format\n".utf8))
+                throw ExitCode.failure
+            }
+            let name = String(spec[spec.startIndex..<colonIndex])
+            let guestPath = String(spec[spec.index(after: colonIndex)...])
+            parsedVolumes.append(VolumeMount(name: name, guestPath: guestPath))
+        }
+
+        let sid = UUID().uuidString
+        let execPath = ProcessInfo.processInfo.arguments[0]
+
+        // Spawn background session process
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: execPath)
+        process.arguments = [
+            "_session-serve",
+            "--sid", sid,
+            "--image", image,
+            "--cpus", String(cpus),
+            "--memory", String(parsedMemory),
+        ]
+        for v in parsedVolumes {
+            process.arguments! += ["--volume", "\(v.name):\(v.guestPath)"]
+        }
+
+        // Detach from terminal
+        process.standardInput = FileHandle.nullDevice
+        process.standardOutput = FileHandle.nullDevice
+        process.standardError = FileHandle.nullDevice
+
+        do {
+            try process.run()
+        } catch {
+            FileHandle.standardError.write(Data("lumina: failed to start session: \(error)\n".utf8))
+            throw ExitCode.failure
+        }
+
+        // Wait for the socket to appear (session process boots VM)
+        let paths = SessionPaths(sid: sid)
+        let deadline = ContinuousClock.now + .seconds(30)
+        while ContinuousClock.now < deadline {
+            if FileManager.default.fileExists(atPath: paths.socket.path) {
+                break
+            }
+            try await Task.sleep(nanoseconds: 100_000_000) // 100ms
+        }
+
+        guard FileManager.default.fileExists(atPath: paths.socket.path) else {
+            FileHandle.standardError.write(Data("lumina: session failed to start within 30s\n".utf8))
+            throw ExitCode.failure
+        }
+
+        // Output session ID
+        let format = resolveOutputFormat(textFlag: false)
+        switch format {
+        case .json:
+            let output = try JSONSerialization.data(withJSONObject: ["sid": sid], options: [.sortedKeys])
+            print(String(data: output, encoding: .utf8)!)
+        case .text:
+            print(sid)
+        }
+    }
+}
+
+struct SessionStop: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(commandName: "stop", abstract: "Stop a running session")
+
+    @Argument(help: "Session ID")
+    var sid: String
+
+    func run() async throws {
+        let client = SessionClient()
+        do {
+            try client.connect(sid: sid)
+            try client.send(.shutdown)
+            _ = try? client.receive()
+            client.disconnect()
+        } catch let error as LuminaError {
+            switch error {
+            case .sessionNotFound:
+                FileHandle.standardError.write(Data("lumina: session '\(sid)' not found\n".utf8))
+            case .sessionDead:
+                FileHandle.standardError.write(Data("lumina: session '\(sid)' is dead (cleaned up)\n".utf8))
+            default:
+                FileHandle.standardError.write(Data("lumina: \(error)\n".utf8))
+            }
+            throw ExitCode.failure
+        }
+    }
+}
+
+struct SessionList: ParsableCommand {
+    static let configuration = CommandConfiguration(commandName: "list", abstract: "List active sessions")
+
+    @Flag(name: .long, help: "Force human-readable text output")
+    var text = false
+
+    func run() throws {
+        let sessions = SessionPaths.listAll()
+        let format = resolveOutputFormat(textFlag: text)
+        switch format {
+        case .json:
+            let encoder = JSONEncoder()
+            encoder.outputFormatting = .sortedKeys
+            encoder.dateEncodingStrategy = .iso8601
+            if let data = try? encoder.encode(sessions),
+               let str = String(data: data, encoding: .utf8) {
+                print(str)
+            }
+        case .text:
+            if sessions.isEmpty {
+                print("No active sessions.")
+            } else {
+                for s in sessions {
+                    let status = s.status == .running ? "running" : "dead"
+                    print("\(s.sid)\t\(s.image)\t\(status)")
+                }
+            }
+        }
+    }
+}
+
+// MARK: - Exec
+
+struct Exec: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(abstract: "Execute a command in a running session")
+
+    @Argument(help: "Session ID")
+    var sid: String
+
+    @Argument(help: "Command to run")
+    var command: String
+
+    @Flag(name: .long, help: "Stream output in real time")
+    var stream = false
+
+    @Flag(name: .long, help: "Force human-readable text output")
+    var text = false
+
+    @Option(name: .long, help: "Timeout (e.g. 30s, 5m)")
+    var timeout: String = "60s"
+
+    @Option(name: [.short, .long], help: "Environment variable (KEY=VAL, repeatable)")
+    var env: [String] = []
+
+    @Option(name: .long, help: "Copy file into VM (local:remote, repeatable)")
+    var copy: [String] = []
+
+    @Option(name: .long, help: "Download file from VM (remote:local, repeatable)")
+    var download: [String] = []
+
+    func run() async throws {
+        guard let parsedTimeout = parseDuration(timeout) else {
+            FileHandle.standardError.write(Data("lumina: invalid timeout '\(timeout)'\n".utf8))
+            throw ExitCode.failure
+        }
+        let timeoutSecs = Int(parsedTimeout.components.seconds)
+
+        var parsedEnv: [String: String] = [:]
+        for pair in env {
+            guard let eqIndex = pair.firstIndex(of: "=") else {
+                FileHandle.standardError.write(Data("lumina: invalid env '\(pair)'. Use KEY=VAL\n".utf8))
+                throw ExitCode.failure
+            }
+            parsedEnv[String(pair[..<eqIndex])] = String(pair[pair.index(after: eqIndex)...])
+        }
+
+        let client = SessionClient()
+        do {
+            try client.connect(sid: sid)
+        } catch let error as LuminaError {
+            switch error {
+            case .sessionNotFound:
+                FileHandle.standardError.write(Data("lumina: session '\(sid)' not found\n".utf8))
+            case .sessionDead:
+                FileHandle.standardError.write(Data("lumina: session '\(sid)' is dead (cleaned up)\n".utf8))
+            default:
+                FileHandle.standardError.write(Data("lumina: \(error)\n".utf8))
+            }
+            throw ExitCode.failure
+        }
+        defer { client.disconnect() }
+
+        // Handle file uploads before exec
+        for spec in copy {
+            guard let colonIndex = spec.firstIndex(of: ":") else {
+                FileHandle.standardError.write(Data("lumina: invalid --copy '\(spec)'\n".utf8))
+                throw ExitCode.failure
+            }
+            let localStr = String(spec[..<colonIndex])
+            let remote = String(spec[spec.index(after: colonIndex)...])
+            try client.send(.upload(localPath: localStr, remotePath: remote))
+            let resp = try client.receive()
+            if case .error(let msg) = resp {
+                FileHandle.standardError.write(Data("lumina: upload failed: \(msg)\n".utf8))
+                throw ExitCode.failure
+            }
+        }
+
+        // Execute
+        let format = resolveOutputFormat(textFlag: text)
+        try client.send(.exec(cmd: command, timeout: timeoutSecs, env: parsedEnv))
+
+        while true {
+            let response = try client.receive()
+            switch response {
+            case .output(let outputStream, let data):
+                switch format {
+                case .json:
+                    printNDJSON(["stream": outputStream.rawValue, "data": data])
+                case .text:
+                    if outputStream == .stdout {
+                        print(data, terminator: "")
+                    } else {
+                        FileHandle.standardError.write(Data(data.utf8))
+                    }
+                }
+            case .exit(let code, let durationMs):
+                switch format {
+                case .json:
+                    printNDJSON(["exit_code": Int(code), "duration_ms": durationMs])
+                case .text:
+                    break
+                }
+
+                // Handle file downloads after exec
+                for spec in download {
+                    guard let colonIndex = spec.firstIndex(of: ":") else { continue }
+                    let remote = String(spec[..<colonIndex])
+                    let localStr = String(spec[spec.index(after: colonIndex)...])
+                    try client.send(.download(remotePath: remote, localPath: localStr))
+                    let dlResp = try client.receive()
+                    if case .error(let msg) = dlResp {
+                        FileHandle.standardError.write(Data("lumina: download failed: \(msg)\n".utf8))
+                    }
+                }
+
+                if code != 0 { throw ExitCode(code) }
+                return
+            case .error(let message):
+                FileHandle.standardError.write(Data("lumina: \(message)\n".utf8))
+                throw ExitCode.failure
+            default:
+                continue
+            }
         }
     }
 }

--- a/Sources/lumina-cli/CLI.swift
+++ b/Sources/lumina-cli/CLI.swift
@@ -8,7 +8,7 @@ struct LuminaCLI: AsyncParsableCommand {
     static let configuration = CommandConfiguration(
         commandName: "lumina",
         abstract: "Native Apple Workload Runtime for Agents — subprocess.run() for virtual machines.",
-        version: "0.2.2",
+        version: "0.3.0",
         subcommands: [Run.self, Pull.self, Images.self, Clean.self,
                       Session.self, Exec.self, SessionServe.self,
                       Volume.self, NetworkCmd.self]

--- a/Sources/lumina-cli/Helpers.swift
+++ b/Sources/lumina-cli/Helpers.swift
@@ -1,0 +1,74 @@
+// Sources/lumina-cli/Helpers.swift
+import Foundation
+import Lumina
+
+// MARK: - Signal Handlers (shared across CLI commands)
+
+/// Install signal handlers via sigaction. Cleans orphaned COW clones on
+/// SIGINT/SIGTERM, then re-raises with default disposition so the parent
+/// process sees the correct wait status (128 + signal).
+func installSignalHandlers() {
+    for sig: Int32 in [SIGINT, SIGTERM] {
+        var action = sigaction()
+        action.__sigaction_u.__sa_handler = { signum in
+            let pid = "\(getpid())"
+            let runsDir = DiskClone.defaultRunsDir
+            if let entries = try? FileManager.default.contentsOfDirectory(
+                at: runsDir, includingPropertiesForKeys: nil
+            ) {
+                for entry in entries {
+                    let pidFile = entry.appendingPathComponent(".pid")
+                    if let content = try? String(contentsOf: pidFile, encoding: .utf8),
+                       content.trimmingCharacters(in: .whitespacesAndNewlines) == pid {
+                        try? FileManager.default.removeItem(at: entry)
+                    }
+                }
+            }
+            signal(signum, SIG_DFL)
+            raise(signum)
+        }
+        sigemptyset(&action.sa_mask)
+        action.sa_flags = 0
+        sigaction(sig, &action, nil)
+    }
+}
+
+// MARK: - Output Format (shared across CLI commands)
+
+enum OutputFormat {
+    case json
+    case text
+}
+
+/// Determine output format: JSON (for agents/pipes) or text (for humans/TTYs).
+/// Priority: LUMINA_FORMAT env > --text flag > isatty() auto-detection.
+func resolveOutputFormat(textFlag: Bool) -> OutputFormat {
+    // 1. LUMINA_FORMAT env var takes highest priority
+    if let envFormat = ProcessInfo.processInfo.environment["LUMINA_FORMAT"]?.lowercased() {
+        switch envFormat {
+        case "json": return .json
+        case "text", "human": return .text
+        default: break
+        }
+    }
+
+    // 2. --text flag explicitly requests human-readable
+    if textFlag { return .text }
+
+    // 3. Auto-detect: TTY -> text, pipe -> JSON
+    return isatty(STDOUT_FILENO) != 0 ? .text : .json
+}
+
+/// Print an NDJSON line (used for streaming output).
+func printNDJSON(_ dict: [String: Any]) {
+    // Use JSONSerialization for heterogeneous dicts, then ensure no literal newlines
+    guard let data = try? JSONSerialization.data(withJSONObject: dict, options: [.sortedKeys, .fragmentsAllowed]),
+          var str = String(data: data, encoding: .utf8) else { return }
+    // JSONSerialization doesn't escape newlines in string values -- replace them
+    str = str.replacingOccurrences(of: "\n", with: "\\n")
+    str = str.replacingOccurrences(of: "\r", with: "\\r")
+    str = str.replacingOccurrences(of: "\t", with: "\\t")
+    print(str)
+    // Flush stdout for real-time streaming
+    fflush(stdout)
+}

--- a/Sources/lumina-cli/SessionProcess.swift
+++ b/Sources/lumina-cli/SessionProcess.swift
@@ -1,0 +1,98 @@
+// Sources/lumina-cli/SessionProcess.swift
+import ArgumentParser
+import Foundation
+import Lumina
+
+/// Hidden subcommand spawned by `session start`. Boots a VM, starts a
+/// SessionServer on a Unix socket, and runs until shutdown or signal.
+struct SessionServe: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "_session-serve",
+        abstract: "Internal: serve a session (spawned by session start)",
+        shouldDisplay: false // hidden from help
+    )
+
+    @Option(help: "Session ID")
+    var sid: String
+
+    @Option(help: "Image name")
+    var image: String = "default"
+
+    @Option(help: "CPU count")
+    var cpus: Int = 2
+
+    @Option(help: "Memory in bytes")
+    var memory: UInt64 = 512 * 1024 * 1024
+
+    @Option(help: "Volume mount (name:guest_path, repeatable)")
+    var volume: [String] = []
+
+    func run() async throws {
+        installSignalHandlers()
+
+        let paths = SessionPaths(sid: sid)
+
+        // Parse volumes into MountPoints by resolving through VolumeStore
+        let volumeStore = VolumeStore()
+        var mounts: [MountPoint] = []
+        for spec in volume {
+            guard let colonIndex = spec.firstIndex(of: ":") else { continue }
+            let name = String(spec[spec.startIndex..<colonIndex])
+            let guestPath = String(spec[spec.index(after: colonIndex)...])
+            guard let hostDir = volumeStore.resolve(name: name) else {
+                FileHandle.standardError.write(Data("lumina: volume '\(name)' not found\n".utf8))
+                throw ExitCode.failure
+            }
+            mounts.append(MountPoint(hostPath: hostDir, guestPath: guestPath))
+        }
+
+        // Boot VM
+        let vmOptions = VMOptions(
+            memory: memory,
+            cpuCount: cpus,
+            image: image,
+            mounts: mounts
+        )
+        let vm = VM(options: vmOptions)
+
+        do {
+            try await vm.bootResult().get()
+        } catch {
+            FileHandle.standardError.write(Data("lumina: session boot failed: \(error)\n".utf8))
+            throw ExitCode.failure
+        }
+
+        // Write session metadata
+        let info = SessionInfo(
+            sid: sid,
+            pid: ProcessInfo.processInfo.processIdentifier,
+            image: image,
+            cpuCount: cpus,
+            memory: memory,
+            created: Date(),
+            status: .running
+        )
+        do {
+            try paths.writeMeta(info)
+        } catch {
+            await vm.shutdown()
+            throw ExitCode.failure
+        }
+
+        // Start session server
+        let server = SessionServer(socketPath: paths.socket)
+        do {
+            try server.bind()
+        } catch {
+            await vm.shutdown()
+            paths.cleanup()
+            throw ExitCode.failure
+        }
+
+        // Serve until shutdown
+        await server.serve(vm: vm)
+
+        // Cleanup
+        paths.cleanup()
+    }
+}

--- a/Tests/LuminaTests/ImageStoreTests.swift
+++ b/Tests/LuminaTests/ImageStoreTests.swift
@@ -59,3 +59,119 @@ import Testing
     let names = store.list()
     #expect(names.isEmpty)
 }
+
+@Test func imageCreateAndInspect() throws {
+    let tmpDir = FileManager.default.temporaryDirectory.appendingPathComponent("lumina-imgtest-\(UUID().uuidString)")
+    try FileManager.default.createDirectory(at: tmpDir, withIntermediateDirectories: true)
+    defer { try? FileManager.default.removeItem(at: tmpDir) }
+
+    let store = ImageStore(baseDir: tmpDir)
+
+    // Create a fake base image
+    let baseDir = tmpDir.appendingPathComponent("default")
+    try FileManager.default.createDirectory(at: baseDir, withIntermediateDirectories: true)
+    try Data("kernel".utf8).write(to: baseDir.appendingPathComponent("vmlinuz"))
+    try Data("initrd".utf8).write(to: baseDir.appendingPathComponent("initrd"))
+    try Data("rootfs".utf8).write(to: baseDir.appendingPathComponent("rootfs.img"))
+    try Data("agent".utf8).write(to: baseDir.appendingPathComponent("lumina-agent"))
+    let modulesDir = baseDir.appendingPathComponent("modules")
+    try FileManager.default.createDirectory(at: modulesDir, withIntermediateDirectories: true)
+
+    // Create a modified rootfs (simulates what DiskClone.rootfs would contain)
+    let modifiedRootfs = tmpDir.appendingPathComponent("modified-rootfs.img")
+    try Data("modified rootfs".utf8).write(to: modifiedRootfs)
+
+    // Create image
+    try store.createImage(
+        name: "python",
+        from: "default",
+        rootfsSource: modifiedRootfs,
+        command: "apk add python3"
+    )
+
+    // Verify image exists
+    let names = store.list()
+    #expect(names.contains("python"))
+
+    // Verify inspect
+    let info = try store.inspect(name: "python")
+    #expect(info.name == "python")
+    #expect(info.base == "default")
+    #expect(info.command == "apk add python3")
+
+    // Verify rootfs is a copy, not a symlink
+    let pythonRootfs = tmpDir.appendingPathComponent("python/rootfs.img")
+    let rootfsContent = try String(contentsOf: pythonRootfs, encoding: .utf8)
+    #expect(rootfsContent == "modified rootfs")
+}
+
+@Test func imageRemoveWithDependents() throws {
+    let tmpDir = FileManager.default.temporaryDirectory.appendingPathComponent("lumina-imgtest-\(UUID().uuidString)")
+    try FileManager.default.createDirectory(at: tmpDir, withIntermediateDirectories: true)
+    defer { try? FileManager.default.removeItem(at: tmpDir) }
+
+    let store = ImageStore(baseDir: tmpDir)
+
+    // Create base + derived images manually
+    let baseDir = tmpDir.appendingPathComponent("default")
+    try FileManager.default.createDirectory(at: baseDir, withIntermediateDirectories: true)
+    try Data("k".utf8).write(to: baseDir.appendingPathComponent("vmlinuz"))
+    try Data("i".utf8).write(to: baseDir.appendingPathComponent("initrd"))
+    try Data("r".utf8).write(to: baseDir.appendingPathComponent("rootfs.img"))
+
+    let pythonDir = tmpDir.appendingPathComponent("python")
+    try FileManager.default.createDirectory(at: pythonDir, withIntermediateDirectories: true)
+    try Data("r2".utf8).write(to: pythonDir.appendingPathComponent("rootfs.img"))
+    let meta = ImageMeta(base: "default", command: "apk add python3", created: Date())
+    try JSONEncoder().encode(meta).write(to: pythonDir.appendingPathComponent("meta.json"))
+
+    // Should refuse to remove default (python depends on it)
+    #expect(throws: LuminaError.self) {
+        try store.removeImage(name: "default")
+    }
+
+    // Should allow removing python (no dependents)
+    try store.removeImage(name: "python")
+    #expect(!store.list().contains("python"))
+}
+
+@Test func imageStoreListExcludesStagingDirs() throws {
+    let tmpDir = FileManager.default.temporaryDirectory.appendingPathComponent("lumina-imgtest-\(UUID().uuidString)")
+    try FileManager.default.createDirectory(at: tmpDir, withIntermediateDirectories: true)
+    defer { try? FileManager.default.removeItem(at: tmpDir) }
+
+    let store = ImageStore(baseDir: tmpDir)
+
+    // Create a real image dir and a staging dir
+    try FileManager.default.createDirectory(
+        at: tmpDir.appendingPathComponent("default"),
+        withIntermediateDirectories: true
+    )
+    try FileManager.default.createDirectory(
+        at: tmpDir.appendingPathComponent(".tmp-staging123"),
+        withIntermediateDirectories: true
+    )
+
+    let names = store.list()
+    #expect(names.contains("default"))
+    #expect(!names.contains(".tmp-staging123"))
+}
+
+@Test func imageStoreCleanStagingDirs() throws {
+    let tmpDir = FileManager.default.temporaryDirectory.appendingPathComponent("lumina-imgtest-\(UUID().uuidString)")
+    try FileManager.default.createDirectory(at: tmpDir, withIntermediateDirectories: true)
+    defer { try? FileManager.default.removeItem(at: tmpDir) }
+
+    let store = ImageStore(baseDir: tmpDir)
+
+    // Create staging dirs
+    let staging1 = tmpDir.appendingPathComponent(".tmp-aaa")
+    let staging2 = tmpDir.appendingPathComponent(".tmp-bbb")
+    try FileManager.default.createDirectory(at: staging1, withIntermediateDirectories: true)
+    try FileManager.default.createDirectory(at: staging2, withIntermediateDirectories: true)
+
+    #expect(FileManager.default.fileExists(atPath: staging1.path))
+    store.cleanStagingDirs()
+    #expect(!FileManager.default.fileExists(atPath: staging1.path))
+    #expect(!FileManager.default.fileExists(atPath: staging2.path))
+}

--- a/Tests/LuminaTests/NetworkSwitchTests.swift
+++ b/Tests/LuminaTests/NetworkSwitchTests.swift
@@ -1,0 +1,59 @@
+// Tests/LuminaTests/NetworkSwitchTests.swift
+import Foundation
+import Testing
+@testable import Lumina
+
+@Test func networkSwitchCreatePort() throws {
+    let sw = NetworkSwitch()
+    let port = try sw.createPort()
+    #expect(port.vmFd >= 0)
+    #expect(port.switchFd >= 0)
+    sw.close()
+}
+
+@Test func networkSwitchRelayFrames() throws {
+    let sw = NetworkSwitch()
+    let port1 = try sw.createPort()
+    let port2 = try sw.createPort()
+
+    sw.startRelay()
+
+    // Write a frame to port1's vmFd (simulating VM1 sending)
+    // Data written to vmFd appears on switchFd, which the relay reads.
+    let frame = Data("test ethernet frame".utf8)
+    let written = frame.withUnsafeBytes { buf in
+        Darwin.write(port1.vmFd, buf.baseAddress!, frame.count)
+    }
+    #expect(written == frame.count)
+
+    // The relay reads from port1.switchFd and writes to port2.switchFd.
+    // Data written to port2.switchFd appears on port2.vmFd.
+    usleep(50_000) // 50ms for relay to process
+
+    var readBuf = [UInt8](repeating: 0, count: 1500)
+    let flags = fcntl(port2.vmFd, F_GETFL)
+    fcntl(port2.vmFd, F_SETFL, flags | O_NONBLOCK)
+    let readCount = Darwin.read(port2.vmFd, &readBuf, readBuf.count)
+
+    #expect(readCount == frame.count)
+    #expect(Data(readBuf[..<readCount]) == frame)
+
+    sw.close()
+}
+
+@Test func networkSwitchIPAssignment() {
+    #expect(NetworkSwitch.ipForIndex(0) == "192.168.100.2")
+    #expect(NetworkSwitch.ipForIndex(1) == "192.168.100.3")
+    #expect(NetworkSwitch.ipForIndex(5) == "192.168.100.7")
+}
+
+@Test func networkSwitchHostsGeneration() {
+    let peers: [(name: String, ip: String)] = [
+        ("db", "192.168.100.2"),
+        ("api", "192.168.100.3"),
+    ]
+    let hosts = NetworkSwitch.generateHosts(peers: peers)
+    #expect(hosts.contains("192.168.100.2 db"))
+    #expect(hosts.contains("192.168.100.3 api"))
+    #expect(hosts.contains("127.0.0.1 localhost"))
+}

--- a/Tests/LuminaTests/NetworkTests.swift
+++ b/Tests/LuminaTests/NetworkTests.swift
@@ -1,0 +1,70 @@
+// Tests/LuminaTests/NetworkTests.swift
+import Foundation
+import Testing
+@testable import Lumina
+
+@Test func networkIPAssignment() {
+    #expect(NetworkSwitch.ipForIndex(0) == "192.168.100.2")
+    #expect(NetworkSwitch.ipForIndex(1) == "192.168.100.3")
+}
+
+@Test func networkHostsGeneration() {
+    let peers: [(name: String, ip: String)] = [
+        ("db", "192.168.100.2"),
+        ("api", "192.168.100.3"),
+    ]
+    let hosts = NetworkSwitch.generateHosts(peers: peers)
+    #expect(hosts.contains("192.168.100.2 db"))
+    #expect(hosts.contains("192.168.100.3 api"))
+}
+
+@Test func vmOptionsPrivateNetworkDefault() {
+    let opts = VMOptions()
+    #expect(opts.privateNetworkFd == nil)
+    #expect(opts.networkHosts == nil)
+    #expect(opts.networkIP == nil)
+}
+
+@Test func vmOptionsFromRunOptionsNetworkDefaults() {
+    let runOpts = RunOptions()
+    let vmOpts = VMOptions(from: runOpts)
+    #expect(vmOpts.privateNetworkFd == nil)
+    #expect(vmOpts.networkHosts == nil)
+    #expect(vmOpts.networkIP == nil)
+}
+
+@Test func initrdPatcherNetworkOverlay() throws {
+    // Create a temporary "base initrd" (just some dummy gzip data)
+    let tempDir = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+    try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+    defer { try? FileManager.default.removeItem(at: tempDir) }
+
+    let initrdURL = tempDir.appendingPathComponent("test-initrd")
+
+    // Create a minimal gzip file as the base initrd
+    let baseContent = Data("base-initrd-content".utf8)
+    try baseContent.write(to: initrdURL)
+
+    let hosts: [String: String] = ["db": "192.168.100.2", "api": "192.168.100.3"]
+    let ip = "192.168.100.2"
+
+    // Should not throw — appends network overlay
+    try InitrdPatcher.appendNetworkOverlay(
+        initrdURL: initrdURL,
+        hosts: hosts,
+        ip: ip
+    )
+
+    // Verify the file grew (overlay was appended)
+    let resultData = try Data(contentsOf: initrdURL)
+    #expect(resultData.count > baseContent.count)
+
+    // Verify it starts with original content
+    #expect(resultData.prefix(baseContent.count) == baseContent)
+}
+
+@Test func networkActorInit() async {
+    // Just verify Network can be initialized
+    let network = Network(name: "test")
+    await network.shutdown()
+}

--- a/Tests/LuminaTests/SessionClientTests.swift
+++ b/Tests/LuminaTests/SessionClientTests.swift
@@ -1,0 +1,31 @@
+// Tests/LuminaTests/SessionClientTests.swift
+import Foundation
+import Testing
+@testable import Lumina
+
+@Test func clientConnectToMissingSid() throws {
+    let client = SessionClient()
+    #expect(throws: LuminaError.self) {
+        try client.connect(sid: "nonexistent-sid-12345")
+    }
+}
+
+@Test func clientDetectsDeadSession() throws {
+    // Create a session dir with a dead PID
+    let sessionsDir = FileManager.default.temporaryDirectory.appendingPathComponent("lumina-test-\(UUID().uuidString)")
+    try FileManager.default.createDirectory(at: sessionsDir, withIntermediateDirectories: true)
+    defer { try? FileManager.default.removeItem(at: sessionsDir) }
+
+    let sid = "dead-session"
+    let paths = SessionPaths(sid: sid, sessionsDir: sessionsDir)
+    let info = SessionInfo(
+        sid: sid, pid: 99999, image: "default", cpuCount: 2,
+        memory: 512 * 1024 * 1024, created: Date(), status: .running
+    )
+    try paths.writeMeta(info)
+
+    let client = SessionClient(sessionsDir: sessionsDir)
+    #expect(throws: LuminaError.self) {
+        try client.connect(sid: sid)
+    }
+}

--- a/Tests/LuminaTests/SessionProtocolTests.swift
+++ b/Tests/LuminaTests/SessionProtocolTests.swift
@@ -1,0 +1,62 @@
+// Tests/LuminaTests/SessionProtocolTests.swift
+import Foundation
+import Testing
+@testable import Lumina
+
+@Test func encodeExecRequest() throws {
+    let req = SessionRequest.exec(cmd: "echo hello", timeout: 30, env: ["FOO": "bar"])
+    let data = try SessionProtocol.encode(req)
+    let str = String(data: data, encoding: .utf8)!
+    #expect(str.hasSuffix("\n"))
+    let json = try JSONSerialization.jsonObject(with: data) as! [String: Any]
+    #expect(json["type"] as? String == "exec")
+    #expect(json["cmd"] as? String == "echo hello")
+    #expect(json["timeout"] as? Int == 30)
+}
+
+@Test func encodeShutdownRequest() throws {
+    let req = SessionRequest.shutdown
+    let data = try SessionProtocol.encode(req)
+    let json = try JSONSerialization.jsonObject(with: data) as! [String: Any]
+    #expect(json["type"] as? String == "shutdown")
+}
+
+@Test func encodeUploadRequest() throws {
+    let req = SessionRequest.upload(localPath: "/host/file.txt", remotePath: "/guest/file.txt")
+    let data = try SessionProtocol.encode(req)
+    let json = try JSONSerialization.jsonObject(with: data) as! [String: Any]
+    #expect(json["type"] as? String == "upload")
+    #expect(json["local_path"] as? String == "/host/file.txt")
+}
+
+@Test func encodeDownloadRequest() throws {
+    let req = SessionRequest.download(remotePath: "/guest/out.txt", localPath: "/host/out.txt")
+    let data = try SessionProtocol.encode(req)
+    let json = try JSONSerialization.jsonObject(with: data) as! [String: Any]
+    #expect(json["type"] as? String == "download")
+}
+
+@Test func decodeOutputResponse() throws {
+    let data = Data("{\"type\":\"output\",\"stream\":\"stdout\",\"data\":\"hello\\n\"}\n".utf8)
+    let msg = try SessionProtocol.decodeResponse(data)
+    #expect(msg == .output(stream: .stdout, data: "hello\n"))
+}
+
+@Test func decodeExitResponse() throws {
+    let data = Data("{\"type\":\"exit\",\"code\":0,\"duration_ms\":150}\n".utf8)
+    let msg = try SessionProtocol.decodeResponse(data)
+    #expect(msg == .exit(code: 0, durationMs: 150))
+}
+
+@Test func decodeErrorResponse() throws {
+    let data = Data("{\"type\":\"error\",\"message\":\"session_dead\"}\n".utf8)
+    let msg = try SessionProtocol.decodeResponse(data)
+    #expect(msg == .error(message: "session_dead"))
+}
+
+@Test func decodeRequestRoundtrip() throws {
+    let req = SessionRequest.exec(cmd: "ls -la", timeout: 60, env: [:])
+    let data = try SessionProtocol.encode(req)
+    let decoded = try SessionProtocol.decodeRequest(data)
+    #expect(decoded == req)
+}

--- a/Tests/LuminaTests/SessionServerTests.swift
+++ b/Tests/LuminaTests/SessionServerTests.swift
@@ -1,0 +1,53 @@
+// Tests/LuminaTests/SessionServerTests.swift
+import Foundation
+import Testing
+@testable import Lumina
+
+@Test func serverSocketCreation() throws {
+    let tmpDir = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+    try FileManager.default.createDirectory(at: tmpDir, withIntermediateDirectories: true)
+    defer { try? FileManager.default.removeItem(at: tmpDir) }
+
+    let socketPath = tmpDir.appendingPathComponent("control.sock")
+    let server = SessionServer(socketPath: socketPath)
+    try server.bind()
+    defer { server.close() }
+
+    #expect(FileManager.default.fileExists(atPath: socketPath.path))
+}
+
+@Test func serverAcceptsConnection() async throws {
+    let tmpDir = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+    try FileManager.default.createDirectory(at: tmpDir, withIntermediateDirectories: true)
+    defer { try? FileManager.default.removeItem(at: tmpDir) }
+
+    let socketPath = tmpDir.appendingPathComponent("control.sock")
+    let server = SessionServer(socketPath: socketPath)
+    try server.bind()
+    defer { server.close() }
+
+    // Connect a client socket
+    let clientFd = socket(AF_UNIX, SOCK_STREAM, 0)
+    #expect(clientFd >= 0)
+    defer { close(clientFd) }
+
+    var addr = sockaddr_un()
+    addr.sun_family = sa_family_t(AF_UNIX)
+    let pathBytes = socketPath.path.utf8CString
+    withUnsafeMutablePointer(to: &addr.sun_path) { ptr in
+        let bound = ptr.withMemoryRebound(to: CChar.self, capacity: 104) { dest in
+            pathBytes.withUnsafeBufferPointer { src in
+                let count = min(src.count, 104)
+                dest.update(from: src.baseAddress!, count: count)
+                return count
+            }
+        }
+        _ = bound
+    }
+    let connectResult = withUnsafePointer(to: &addr) { ptr in
+        ptr.withMemoryRebound(to: sockaddr.self, capacity: 1) { sockPtr in
+            Darwin.connect(clientFd, sockPtr, socklen_t(MemoryLayout<sockaddr_un>.size))
+        }
+    }
+    #expect(connectResult == 0)
+}

--- a/Tests/LuminaTests/SessionTests.swift
+++ b/Tests/LuminaTests/SessionTests.swift
@@ -1,0 +1,41 @@
+// Tests/LuminaTests/SessionTests.swift
+import Foundation
+import Testing
+@testable import Lumina
+
+@Test func sessionOptionsDefaults() {
+    let opts = SessionOptions()
+    #expect(opts.cpuCount == 2)
+    #expect(opts.memory == 512 * 1024 * 1024)
+    #expect(opts.image == "default")
+    #expect(opts.volumes.isEmpty)
+}
+
+@Test func sessionInfoSerialization() throws {
+    let info = SessionInfo(
+        sid: "test-uuid",
+        pid: 1234,
+        image: "default",
+        cpuCount: 2,
+        memory: 512 * 1024 * 1024,
+        created: Date(timeIntervalSince1970: 1000),
+        status: .running
+    )
+    let data = try JSONEncoder().encode(info)
+    let decoded = try JSONDecoder().decode(SessionInfo.self, from: data)
+    #expect(decoded.sid == "test-uuid")
+    #expect(decoded.pid == 1234)
+    #expect(decoded.status == .running)
+}
+
+@Test func sessionPaths() {
+    let session = SessionPaths(sid: "abc-123")
+    #expect(session.directory.path.hasSuffix("/.lumina/sessions/abc-123"))
+    #expect(session.socket.path.hasSuffix("/control.sock"))
+    #expect(session.metaFile.path.hasSuffix("/meta.json"))
+}
+
+@Test func sessionStateEquality() {
+    #expect(SessionState.running == SessionState.running)
+    #expect(SessionState.running != SessionState.dead)
+}

--- a/Tests/LuminaTests/VolumeStoreTests.swift
+++ b/Tests/LuminaTests/VolumeStoreTests.swift
@@ -1,0 +1,63 @@
+// Tests/LuminaTests/VolumeStoreTests.swift
+import Foundation
+import Testing
+@testable import Lumina
+
+@Test func volumeCreateAndResolve() throws {
+    let tmpDir = FileManager.default.temporaryDirectory.appendingPathComponent("lumina-voltest-\(UUID().uuidString)")
+    defer { try? FileManager.default.removeItem(at: tmpDir) }
+
+    let store = VolumeStore(baseDir: tmpDir)
+    try store.create(name: "pycache")
+
+    let resolved = store.resolve(name: "pycache")
+    #expect(resolved != nil)
+    #expect(resolved!.path.hasSuffix("/pycache/data"))
+
+    var isDir: ObjCBool = false
+    #expect(FileManager.default.fileExists(atPath: resolved!.path, isDirectory: &isDir))
+    #expect(isDir.boolValue)
+}
+
+@Test func volumeList() throws {
+    let tmpDir = FileManager.default.temporaryDirectory.appendingPathComponent("lumina-voltest-\(UUID().uuidString)")
+    defer { try? FileManager.default.removeItem(at: tmpDir) }
+
+    let store = VolumeStore(baseDir: tmpDir)
+    try store.create(name: "cache")
+    try store.create(name: "data")
+
+    let names = store.list()
+    #expect(names.contains("cache"))
+    #expect(names.contains("data"))
+}
+
+@Test func volumeRemove() throws {
+    let tmpDir = FileManager.default.temporaryDirectory.appendingPathComponent("lumina-voltest-\(UUID().uuidString)")
+    defer { try? FileManager.default.removeItem(at: tmpDir) }
+
+    let store = VolumeStore(baseDir: tmpDir)
+    try store.create(name: "temp")
+    try store.remove(name: "temp")
+
+    #expect(store.resolve(name: "temp") == nil)
+    #expect(!store.list().contains("temp"))
+}
+
+@Test func volumeInspect() throws {
+    let tmpDir = FileManager.default.temporaryDirectory.appendingPathComponent("lumina-voltest-\(UUID().uuidString)")
+    defer { try? FileManager.default.removeItem(at: tmpDir) }
+
+    let store = VolumeStore(baseDir: tmpDir)
+    try store.create(name: "test")
+
+    let info = try store.inspect(name: "test")
+    #expect(info.name == "test")
+    #expect(info.sizeBytes == 0)
+}
+
+@Test func volumeResolveMissing() {
+    let tmpDir = FileManager.default.temporaryDirectory.appendingPathComponent("lumina-voltest-\(UUID().uuidString)")
+    let store = VolumeStore(baseDir: tmpDir)
+    #expect(store.resolve(name: "nonexistent") == nil)
+}

--- a/docs/superpowers/plans/2026-04-09-lumina-v1-p0.md
+++ b/docs/superpowers/plans/2026-04-09-lumina-v1-p0.md
@@ -1,0 +1,2713 @@
+# Lumina v1 P0 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Implement Sessions, Custom Images, Persistent Volumes, and VM-to-VM Networking for Lumina v1 P0.
+
+**Architecture:** Per-session background processes with Unix domain sockets. No daemon. Filesystem as session registry. ImageStore handles image creation with staging-dir atomicity. VolumeStore manages named host directories via VirtioFS. NetworkSwitch relays SOCK_DGRAM ethernet frames between VMs in a single process.
+
+**Tech Stack:** Swift 6, Virtualization.framework, XCTest/swift-testing, ArgumentParser
+
+**Spec:** `docs/superpowers/specs/2026-04-09-lumina-v1-p0-design.md`
+
+---
+
+## Phase 1: Sessions
+
+### Task 1: Session types and metadata
+
+**Files:**
+- Modify: `Sources/Lumina/Types.swift`
+- Create: `Sources/Lumina/Session.swift`
+- Test: `Tests/LuminaTests/SessionTests.swift`
+
+- [ ] **Step 1: Write failing tests for Session types**
+
+```swift
+// Tests/LuminaTests/SessionTests.swift
+import Foundation
+import Testing
+@testable import Lumina
+
+@Test func sessionOptionsDefaults() {
+    let opts = SessionOptions()
+    #expect(opts.cpuCount == 2)
+    #expect(opts.memory == 512 * 1024 * 1024)
+    #expect(opts.image == "default")
+    #expect(opts.volumes.isEmpty)
+}
+
+@Test func sessionInfoSerialization() throws {
+    let info = SessionInfo(
+        sid: "test-uuid",
+        pid: 1234,
+        image: "default",
+        cpuCount: 2,
+        memory: 512 * 1024 * 1024,
+        created: Date(timeIntervalSince1970: 1000),
+        status: .running
+    )
+    let data = try JSONEncoder().encode(info)
+    let decoded = try JSONDecoder().decode(SessionInfo.self, from: data)
+    #expect(decoded.sid == "test-uuid")
+    #expect(decoded.pid == 1234)
+    #expect(decoded.status == .running)
+}
+
+@Test func sessionPaths() {
+    let session = SessionPaths(sid: "abc-123")
+    #expect(session.directory.path.hasSuffix("/.lumina/sessions/abc-123"))
+    #expect(session.socket.path.hasSuffix("/control.sock"))
+    #expect(session.metaFile.path.hasSuffix("/meta.json"))
+}
+
+@Test func sessionStateEquality() {
+    #expect(SessionState.running == SessionState.running)
+    #expect(SessionState.running != SessionState.dead)
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `swift test --filter SessionTests 2>&1 | head -20`
+Expected: Compilation errors — types don't exist yet.
+
+- [ ] **Step 3: Implement Session types**
+
+Add to `Sources/Lumina/Types.swift` after the existing `LuminaError` enum:
+
+```swift
+// MARK: - Session Types
+
+public struct SessionOptions: Sendable {
+    public var cpuCount: Int
+    public var memory: UInt64
+    public var image: String
+    public var timeout: Duration
+    public var env: [String: String]
+    public var volumes: [VolumeMount]
+
+    public init(
+        cpuCount: Int = 2,
+        memory: UInt64 = 512 * 1024 * 1024,
+        image: String = "default",
+        timeout: Duration = .seconds(60),
+        env: [String: String] = [:],
+        volumes: [VolumeMount] = []
+    ) {
+        self.cpuCount = cpuCount
+        self.memory = memory
+        self.image = image
+        self.timeout = timeout
+        self.env = env
+        self.volumes = volumes
+    }
+}
+
+public struct SessionInfo: Sendable, Codable {
+    public let sid: String
+    public let pid: Int32
+    public let image: String
+    public let cpuCount: Int
+    public let memory: UInt64
+    public let created: Date
+    public var status: SessionState
+
+    public init(sid: String, pid: Int32, image: String, cpuCount: Int, memory: UInt64, created: Date, status: SessionState) {
+        self.sid = sid
+        self.pid = pid
+        self.image = image
+        self.cpuCount = cpuCount
+        self.memory = memory
+        self.created = created
+        self.status = status
+    }
+}
+
+public enum SessionState: String, Sendable, Codable, Equatable {
+    case running
+    case dead
+}
+
+public struct VolumeMount: Sendable {
+    public let name: String
+    public let guestPath: String
+
+    public init(name: String, guestPath: String) {
+        self.name = name
+        self.guestPath = guestPath
+    }
+}
+```
+
+Also add session errors to `LuminaError`:
+
+```swift
+case sessionNotFound(String)
+case sessionDead(String)
+case sessionFailed(String)
+```
+
+Create `Sources/Lumina/Session.swift`:
+
+```swift
+// Sources/Lumina/Session.swift
+import Foundation
+
+public struct SessionPaths: Sendable {
+    public let sid: String
+    public let directory: URL
+    public let socket: URL
+    public let metaFile: URL
+    public let runDir: URL
+
+    public static let defaultSessionsDir: URL = {
+        FileManager.default.homeDirectoryForCurrentUser
+            .appendingPathComponent(".lumina/sessions")
+    }()
+
+    public init(sid: String, sessionsDir: URL = SessionPaths.defaultSessionsDir) {
+        self.sid = sid
+        self.directory = sessionsDir.appendingPathComponent(sid)
+        self.socket = self.directory.appendingPathComponent("control.sock")
+        self.metaFile = self.directory.appendingPathComponent("meta.json")
+        self.runDir = self.directory.appendingPathComponent("run")
+    }
+
+    /// Write session metadata to disk.
+    public func writeMeta(_ info: SessionInfo) throws {
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        let data = try JSONEncoder().encode(info)
+        try data.write(to: metaFile)
+    }
+
+    /// Read session metadata from disk. Returns nil if file doesn't exist.
+    public func readMeta() -> SessionInfo? {
+        guard let data = try? Data(contentsOf: metaFile) else { return nil }
+        return try? JSONDecoder().decode(SessionInfo.self, from: data)
+    }
+
+    /// Check if the session's process is alive.
+    public func isAlive() -> Bool {
+        guard let info = readMeta() else { return false }
+        return kill(info.pid, 0) == 0
+    }
+
+    /// Remove the session directory and all contents.
+    public func cleanup() {
+        try? FileManager.default.removeItem(at: directory)
+    }
+
+    /// List all sessions, checking liveness.
+    public static func listAll(sessionsDir: URL = SessionPaths.defaultSessionsDir) -> [SessionInfo] {
+        let fm = FileManager.default
+        guard let entries = try? fm.contentsOfDirectory(
+            at: sessionsDir,
+            includingPropertiesForKeys: [.isDirectoryKey]
+        ) else { return [] }
+
+        return entries.compactMap { entry -> SessionInfo? in
+            let sid = entry.lastPathComponent
+            let paths = SessionPaths(sid: sid, sessionsDir: sessionsDir)
+            guard var info = paths.readMeta() else { return nil }
+            if kill(info.pid, 0) != 0 {
+                info.status = .dead
+            }
+            return info
+        }.sorted { $0.created < $1.created }
+    }
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `swift test --filter SessionTests 2>&1 | tail -5`
+Expected: All 4 tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Sources/Lumina/Types.swift Sources/Lumina/Session.swift Tests/LuminaTests/SessionTests.swift
+git commit -m "feat: add Session types, SessionPaths, and SessionInfo metadata"
+```
+
+---
+
+### Task 2: Session IPC protocol
+
+**Files:**
+- Create: `Sources/Lumina/SessionProtocol.swift`
+- Test: `Tests/LuminaTests/SessionProtocolTests.swift`
+
+- [ ] **Step 1: Write failing tests for SessionProtocol**
+
+```swift
+// Tests/LuminaTests/SessionProtocolTests.swift
+import Foundation
+import Testing
+@testable import Lumina
+
+@Test func encodeExecRequest() throws {
+    let req = SessionRequest.exec(cmd: "echo hello", timeout: 30, env: ["FOO": "bar"])
+    let data = try SessionProtocol.encode(req)
+    let str = String(data: data, encoding: .utf8)!
+    #expect(str.hasSuffix("\n"))
+    let json = try JSONSerialization.jsonObject(with: data) as! [String: Any]
+    #expect(json["type"] as? String == "exec")
+    #expect(json["cmd"] as? String == "echo hello")
+    #expect(json["timeout"] as? Int == 30)
+}
+
+@Test func encodeShutdownRequest() throws {
+    let req = SessionRequest.shutdown
+    let data = try SessionProtocol.encode(req)
+    let json = try JSONSerialization.jsonObject(with: data) as! [String: Any]
+    #expect(json["type"] as? String == "shutdown")
+}
+
+@Test func encodeUploadRequest() throws {
+    let req = SessionRequest.upload(localPath: "/host/file.txt", remotePath: "/guest/file.txt")
+    let data = try SessionProtocol.encode(req)
+    let json = try JSONSerialization.jsonObject(with: data) as! [String: Any]
+    #expect(json["type"] as? String == "upload")
+    #expect(json["local_path"] as? String == "/host/file.txt")
+}
+
+@Test func encodeDownloadRequest() throws {
+    let req = SessionRequest.download(remotePath: "/guest/out.txt", localPath: "/host/out.txt")
+    let data = try SessionProtocol.encode(req)
+    let json = try JSONSerialization.jsonObject(with: data) as! [String: Any]
+    #expect(json["type"] as? String == "download")
+}
+
+@Test func decodeOutputResponse() throws {
+    let data = Data("{\"type\":\"output\",\"stream\":\"stdout\",\"data\":\"hello\\n\"}\n".utf8)
+    let msg = try SessionProtocol.decodeResponse(data)
+    #expect(msg == .output(stream: .stdout, data: "hello\n"))
+}
+
+@Test func decodeExitResponse() throws {
+    let data = Data("{\"type\":\"exit\",\"code\":0,\"duration_ms\":150}\n".utf8)
+    let msg = try SessionProtocol.decodeResponse(data)
+    #expect(msg == .exit(code: 0, durationMs: 150))
+}
+
+@Test func decodeErrorResponse() throws {
+    let data = Data("{\"type\":\"error\",\"message\":\"session_dead\"}\n".utf8)
+    let msg = try SessionProtocol.decodeResponse(data)
+    #expect(msg == .error(message: "session_dead"))
+}
+
+@Test func decodeRequestRoundtrip() throws {
+    let req = SessionRequest.exec(cmd: "ls -la", timeout: 60, env: [:])
+    let data = try SessionProtocol.encode(req)
+    let decoded = try SessionProtocol.decodeRequest(data)
+    #expect(decoded == req)
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `swift test --filter SessionProtocolTests 2>&1 | head -20`
+Expected: Compilation errors — SessionProtocol doesn't exist.
+
+- [ ] **Step 3: Implement SessionProtocol**
+
+```swift
+// Sources/Lumina/SessionProtocol.swift
+import Foundation
+
+// MARK: - Session Request (client → server)
+
+public enum SessionRequest: Sendable, Equatable {
+    case exec(cmd: String, timeout: Int, env: [String: String])
+    case upload(localPath: String, remotePath: String)
+    case download(remotePath: String, localPath: String)
+    case shutdown
+}
+
+// MARK: - Session Response (server → client)
+
+public enum SessionResponse: Sendable, Equatable {
+    case output(stream: OutputStream, data: String)
+    case exit(code: Int32, durationMs: Int)
+    case error(message: String)
+    case uploadDone(path: String)
+    case downloadDone(path: String)
+}
+
+// MARK: - Codec
+
+public enum SessionProtocol {
+    static let maxMessageSize = 65_536
+
+    public static func encode(_ request: SessionRequest) throws -> Data {
+        let dict: [String: Any]
+        switch request {
+        case .exec(let cmd, let timeout, let env):
+            dict = ["type": "exec", "cmd": cmd, "timeout": timeout, "env": env]
+        case .upload(let localPath, let remotePath):
+            dict = ["type": "upload", "local_path": localPath, "remote_path": remotePath]
+        case .download(let remotePath, let localPath):
+            dict = ["type": "download", "remote_path": remotePath, "local_path": localPath]
+        case .shutdown:
+            dict = ["type": "shutdown"]
+        }
+        var data = try JSONSerialization.data(withJSONObject: dict, options: [.sortedKeys])
+        data.append(contentsOf: [UInt8(ascii: "\n")])
+        return data
+    }
+
+    public static func encode(_ response: SessionResponse) throws -> Data {
+        let dict: [String: Any]
+        switch response {
+        case .output(let stream, let data):
+            dict = ["type": "output", "stream": stream.rawValue, "data": data]
+        case .exit(let code, let durationMs):
+            dict = ["type": "exit", "code": Int(code), "duration_ms": durationMs]
+        case .error(let message):
+            dict = ["type": "error", "message": message]
+        case .uploadDone(let path):
+            dict = ["type": "upload_done", "path": path]
+        case .downloadDone(let path):
+            dict = ["type": "download_done", "path": path]
+        }
+        var data = try JSONSerialization.data(withJSONObject: dict, options: [.sortedKeys])
+        data.append(contentsOf: [UInt8(ascii: "\n")])
+        return data
+    }
+
+    public static func decodeRequest(_ data: Data) throws -> SessionRequest {
+        let trimmed = data.prefix(while: { $0 != UInt8(ascii: "\n") })
+        guard let json = try? JSONSerialization.jsonObject(with: trimmed) as? [String: Any],
+              let type = json["type"] as? String
+        else {
+            throw LuminaError.protocolError("Invalid JSON in session request")
+        }
+
+        switch type {
+        case "exec":
+            guard let cmd = json["cmd"] as? String,
+                  let timeout = json["timeout"] as? Int else {
+                throw LuminaError.protocolError("Malformed exec request")
+            }
+            let env = json["env"] as? [String: String] ?? [:]
+            return .exec(cmd: cmd, timeout: timeout, env: env)
+        case "upload":
+            guard let localPath = json["local_path"] as? String,
+                  let remotePath = json["remote_path"] as? String else {
+                throw LuminaError.protocolError("Malformed upload request")
+            }
+            return .upload(localPath: localPath, remotePath: remotePath)
+        case "download":
+            guard let remotePath = json["remote_path"] as? String,
+                  let localPath = json["local_path"] as? String else {
+                throw LuminaError.protocolError("Malformed download request")
+            }
+            return .download(remotePath: remotePath, localPath: localPath)
+        case "shutdown":
+            return .shutdown
+        default:
+            throw LuminaError.protocolError("Unknown session request type: \(type)")
+        }
+    }
+
+    public static func decodeResponse(_ data: Data) throws -> SessionResponse {
+        let trimmed = data.prefix(while: { $0 != UInt8(ascii: "\n") })
+        guard let json = try? JSONSerialization.jsonObject(with: trimmed) as? [String: Any],
+              let type = json["type"] as? String
+        else {
+            throw LuminaError.protocolError("Invalid JSON in session response")
+        }
+
+        switch type {
+        case "output":
+            guard let streamStr = json["stream"] as? String,
+                  let stream = OutputStream(rawValue: streamStr),
+                  let data = json["data"] as? String else {
+                throw LuminaError.protocolError("Malformed output response")
+            }
+            return .output(stream: stream, data: data)
+        case "exit":
+            guard let code = json["code"] as? Int,
+                  let durationMs = json["duration_ms"] as? Int else {
+                throw LuminaError.protocolError("Malformed exit response")
+            }
+            return .exit(code: Int32(code), durationMs: durationMs)
+        case "error":
+            guard let message = json["message"] as? String else {
+                throw LuminaError.protocolError("Malformed error response")
+            }
+            return .error(message: message)
+        case "upload_done":
+            guard let path = json["path"] as? String else {
+                throw LuminaError.protocolError("Malformed upload_done response")
+            }
+            return .uploadDone(path: path)
+        case "download_done":
+            guard let path = json["path"] as? String else {
+                throw LuminaError.protocolError("Malformed download_done response")
+            }
+            return .downloadDone(path: path)
+        default:
+            throw LuminaError.protocolError("Unknown session response type: \(type)")
+        }
+    }
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `swift test --filter SessionProtocolTests 2>&1 | tail -5`
+Expected: All 8 tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Sources/Lumina/SessionProtocol.swift Tests/LuminaTests/SessionProtocolTests.swift
+git commit -m "feat: add SessionProtocol with request/response codec"
+```
+
+---
+
+### Task 3: Session server
+
+**Files:**
+- Create: `Sources/Lumina/SessionServer.swift`
+- Test: `Tests/LuminaTests/SessionServerTests.swift`
+
+The session server listens on a Unix domain socket, accepts one client at a time, reads `SessionRequest` messages, dispatches them to the VM actor, and writes `SessionResponse` messages back.
+
+- [ ] **Step 1: Write failing tests for SessionServer**
+
+```swift
+// Tests/LuminaTests/SessionServerTests.swift
+import Foundation
+import Testing
+@testable import Lumina
+
+@Test func serverSocketCreation() throws {
+    let tmpDir = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+    try FileManager.default.createDirectory(at: tmpDir, withIntermediateDirectories: true)
+    defer { try? FileManager.default.removeItem(at: tmpDir) }
+
+    let socketPath = tmpDir.appendingPathComponent("control.sock")
+    let server = SessionServer(socketPath: socketPath)
+    try server.bind()
+    defer { server.close() }
+
+    #expect(FileManager.default.fileExists(atPath: socketPath.path))
+}
+
+@Test func serverAcceptsConnection() async throws {
+    let tmpDir = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+    try FileManager.default.createDirectory(at: tmpDir, withIntermediateDirectories: true)
+    defer { try? FileManager.default.removeItem(at: tmpDir) }
+
+    let socketPath = tmpDir.appendingPathComponent("control.sock")
+    let server = SessionServer(socketPath: socketPath)
+    try server.bind()
+    defer { server.close() }
+
+    // Connect a client socket
+    let clientFd = socket(AF_UNIX, SOCK_STREAM, 0)
+    #expect(clientFd >= 0)
+    defer { close(clientFd) }
+
+    var addr = sockaddr_un()
+    addr.sun_family = sa_family_t(AF_UNIX)
+    let pathBytes = socketPath.path.utf8CString
+    withUnsafeMutablePointer(to: &addr.sun_path) { ptr in
+        let bound = ptr.withMemoryRebound(to: CChar.self, capacity: 104) { dest in
+            pathBytes.withUnsafeBufferPointer { src in
+                let count = min(src.count, 104)
+                dest.update(from: src.baseAddress!, count: count)
+                return count
+            }
+        }
+        _ = bound
+    }
+    let connectResult = withUnsafePointer(to: &addr) { ptr in
+        ptr.withMemoryRebound(to: sockaddr.self, capacity: 1) { sockPtr in
+            Darwin.connect(clientFd, sockPtr, socklen_t(MemoryLayout<sockaddr_un>.size))
+        }
+    }
+    #expect(connectResult == 0)
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `swift test --filter SessionServerTests 2>&1 | head -20`
+Expected: Compilation errors — SessionServer doesn't exist.
+
+- [ ] **Step 3: Implement SessionServer**
+
+```swift
+// Sources/Lumina/SessionServer.swift
+import Foundation
+
+/// Listens on a Unix domain socket and dispatches SessionRequest messages
+/// to a VM actor. Each accepted connection is served sequentially — one
+/// client at a time (the CLI client connects, sends a request, gets a
+/// response, disconnects).
+public final class SessionServer: @unchecked Sendable {
+    private let socketPath: URL
+    private var serverFd: Int32 = -1
+    private let lock = NSLock()
+
+    public init(socketPath: URL) {
+        self.socketPath = socketPath
+    }
+
+    /// Bind and listen on the Unix domain socket.
+    public func bind() throws {
+        // Remove stale socket file
+        try? FileManager.default.removeItem(at: socketPath)
+
+        serverFd = socket(AF_UNIX, SOCK_STREAM, 0)
+        guard serverFd >= 0 else {
+            throw LuminaError.sessionFailed("Failed to create socket: \(errno)")
+        }
+
+        var addr = sockaddr_un()
+        addr.sun_family = sa_family_t(AF_UNIX)
+        let path = socketPath.path
+        let pathBytes = path.utf8CString
+        withUnsafeMutablePointer(to: &addr.sun_path) { ptr in
+            ptr.withMemoryRebound(to: CChar.self, capacity: 104) { dest in
+                pathBytes.withUnsafeBufferPointer { src in
+                    let count = min(src.count, 104)
+                    dest.update(from: src.baseAddress!, count: count)
+                }
+            }
+        }
+
+        let bindResult = withUnsafePointer(to: &addr) { ptr in
+            ptr.withMemoryRebound(to: sockaddr.self, capacity: 1) { sockPtr in
+                Darwin.bind(serverFd, sockPtr, socklen_t(MemoryLayout<sockaddr_un>.size))
+            }
+        }
+        guard bindResult == 0 else {
+            Darwin.close(serverFd)
+            serverFd = -1
+            throw LuminaError.sessionFailed("Failed to bind socket: \(errno)")
+        }
+
+        guard listen(serverFd, 5) == 0 else {
+            Darwin.close(serverFd)
+            serverFd = -1
+            throw LuminaError.sessionFailed("Failed to listen on socket: \(errno)")
+        }
+    }
+
+    /// Accept a client connection. Blocks until a client connects.
+    /// Returns file handles for reading and writing.
+    public func accept() throws -> (read: FileHandle, write: FileHandle) {
+        let clientFd = Darwin.accept(serverFd, nil, nil)
+        guard clientFd >= 0 else {
+            throw LuminaError.sessionFailed("Failed to accept connection: \(errno)")
+        }
+        return (
+            read: FileHandle(fileDescriptor: clientFd, closeOnDealloc: false),
+            write: FileHandle(fileDescriptor: clientFd, closeOnDealloc: false)
+        )
+    }
+
+    /// Read one NDJSON line from a file handle.
+    public func readMessage(from handle: FileHandle) throws -> Data {
+        var buffer = Data()
+        while true {
+            let chunk = handle.availableData
+            if chunk.isEmpty {
+                if buffer.isEmpty { throw LuminaError.connectionFailed }
+                return buffer
+            }
+            buffer.append(chunk)
+            if buffer.count > SessionProtocol.maxMessageSize {
+                throw LuminaError.protocolError("Session message exceeds 64KB")
+            }
+            if let newlineIdx = buffer.firstIndex(of: UInt8(ascii: "\n")) {
+                let lineEnd = buffer.index(after: newlineIdx)
+                let line = Data(buffer[buffer.startIndex..<lineEnd])
+                return line
+            }
+        }
+    }
+
+    /// Write a SessionResponse to the client.
+    public func writeResponse(_ response: SessionResponse, to handle: FileHandle) throws {
+        let data = try SessionProtocol.encode(response)
+        handle.write(data)
+    }
+
+    /// Close the server socket.
+    public func close() {
+        if serverFd >= 0 {
+            Darwin.close(serverFd)
+            serverFd = -1
+        }
+        try? FileManager.default.removeItem(at: socketPath)
+    }
+
+    /// Run the server loop: accept connections, dispatch requests to the VM.
+    /// This blocks indefinitely until the server is closed or a shutdown request arrives.
+    public func serve(vm: VM) async {
+        while serverFd >= 0 {
+            let handles: (read: FileHandle, write: FileHandle)
+            do {
+                handles = try accept()
+            } catch {
+                if serverFd < 0 { break } // server was closed
+                continue
+            }
+
+            let clientFd = handles.read.fileDescriptor
+            defer { Darwin.close(clientFd) }
+
+            // Read and dispatch messages until client disconnects
+            while true {
+                let msgData: Data
+                do {
+                    msgData = try readMessage(from: handles.read)
+                } catch {
+                    break // client disconnected
+                }
+
+                let request: SessionRequest
+                do {
+                    request = try SessionProtocol.decodeRequest(msgData)
+                } catch {
+                    try? writeResponse(.error(message: "Invalid request: \(error)"), to: handles.write)
+                    break
+                }
+
+                switch request {
+                case .exec(let cmd, let timeout, let env):
+                    await handleExec(cmd: cmd, timeout: timeout, env: env, vm: vm, handle: handles.write)
+
+                case .upload(let localPath, let remotePath):
+                    await handleUpload(localPath: localPath, remotePath: remotePath, vm: vm, handle: handles.write)
+
+                case .download(let remotePath, let localPath):
+                    await handleDownload(remotePath: remotePath, localPath: localPath, vm: vm, handle: handles.write)
+
+                case .shutdown:
+                    await vm.shutdown()
+                    try? writeResponse(.exit(code: 0, durationMs: 0), to: handles.write)
+                    close()
+                    return
+                }
+            }
+        }
+    }
+
+    // MARK: - Request Handlers
+
+    private func handleExec(cmd: String, timeout: Int, env: [String: String], vm: VM, handle: FileHandle) async {
+        let start = ContinuousClock.now
+        do {
+            let result = try await vm.exec(cmd, timeout: timeout, env: env)
+            let ms = Int((ContinuousClock.now - start).components.seconds * 1000)
+            // Send stdout/stderr as output messages, then exit
+            if !result.stdout.isEmpty {
+                try? writeResponse(.output(stream: .stdout, data: result.stdout), to: handle)
+            }
+            if !result.stderr.isEmpty {
+                try? writeResponse(.output(stream: .stderr, data: result.stderr), to: handle)
+            }
+            try? writeResponse(.exit(code: result.exitCode, durationMs: ms), to: handle)
+        } catch {
+            try? writeResponse(.error(message: String(describing: error)), to: handle)
+        }
+    }
+
+    private func handleUpload(localPath: String, remotePath: String, vm: VM, handle: FileHandle) async {
+        do {
+            let upload = FileUpload(localPath: URL(fileURLWithPath: localPath), remotePath: remotePath)
+            try vm.uploadFiles([upload])
+            try? writeResponse(.uploadDone(path: remotePath), to: handle)
+        } catch {
+            try? writeResponse(.error(message: "Upload failed: \(error)"), to: handle)
+        }
+    }
+
+    private func handleDownload(remotePath: String, localPath: String, vm: VM, handle: FileHandle) async {
+        do {
+            let download = FileDownload(remotePath: remotePath, localPath: URL(fileURLWithPath: localPath))
+            try vm.downloadFiles([download])
+            try? writeResponse(.downloadDone(path: localPath), to: handle)
+        } catch {
+            try? writeResponse(.error(message: "Download failed: \(error)"), to: handle)
+        }
+    }
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `swift test --filter SessionServerTests 2>&1 | tail -5`
+Expected: Both tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Sources/Lumina/SessionServer.swift Tests/LuminaTests/SessionServerTests.swift
+git commit -m "feat: add SessionServer with Unix socket listener and request dispatch"
+```
+
+---
+
+### Task 4: Session client
+
+**Files:**
+- Create: `Sources/Lumina/SessionClient.swift`
+- Test: `Tests/LuminaTests/SessionClientTests.swift`
+
+- [ ] **Step 1: Write failing tests for SessionClient**
+
+```swift
+// Tests/LuminaTests/SessionClientTests.swift
+import Foundation
+import Testing
+@testable import Lumina
+
+@Test func clientConnectToMissingSid() throws {
+    let client = SessionClient()
+    #expect(throws: LuminaError.self) {
+        try client.connect(sid: "nonexistent-sid-12345")
+    }
+}
+
+@Test func clientDetectsDeadSession() throws {
+    // Create a session dir with a dead PID
+    let sessionsDir = FileManager.default.temporaryDirectory.appendingPathComponent("lumina-test-\(UUID().uuidString)")
+    try FileManager.default.createDirectory(at: sessionsDir, withIntermediateDirectories: true)
+    defer { try? FileManager.default.removeItem(at: sessionsDir) }
+
+    let sid = "dead-session"
+    let paths = SessionPaths(sid: sid, sessionsDir: sessionsDir)
+    let info = SessionInfo(
+        sid: sid, pid: 99999, image: "default", cpuCount: 2,
+        memory: 512 * 1024 * 1024, created: Date(), status: .running
+    )
+    try paths.writeMeta(info)
+
+    let client = SessionClient(sessionsDir: sessionsDir)
+    #expect(throws: LuminaError.self) {
+        try client.connect(sid: sid)
+    }
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `swift test --filter SessionClientTests 2>&1 | head -20`
+Expected: Compilation errors — SessionClient doesn't exist.
+
+- [ ] **Step 3: Implement SessionClient**
+
+```swift
+// Sources/Lumina/SessionClient.swift
+import Foundation
+
+/// Connects to a session's Unix domain socket and sends/receives
+/// SessionProtocol messages. Used by the CLI `exec` and `session stop` commands.
+public final class SessionClient: @unchecked Sendable {
+    private let sessionsDir: URL
+    private var clientFd: Int32 = -1
+    private var readHandle: FileHandle?
+    private var writeHandle: FileHandle?
+
+    public init(sessionsDir: URL = SessionPaths.defaultSessionsDir) {
+        self.sessionsDir = sessionsDir
+    }
+
+    /// Connect to a session by ID. Validates the session exists and is alive.
+    public func connect(sid: String) throws {
+        let paths = SessionPaths(sid: sid, sessionsDir: sessionsDir)
+
+        // Check if session directory exists
+        guard FileManager.default.fileExists(atPath: paths.directory.path) else {
+            throw LuminaError.sessionNotFound(sid)
+        }
+
+        // Check if session process is alive
+        if let info = paths.readMeta(), kill(info.pid, 0) != 0 {
+            paths.cleanup()
+            throw LuminaError.sessionDead(sid)
+        }
+
+        // Connect to Unix socket
+        clientFd = socket(AF_UNIX, SOCK_STREAM, 0)
+        guard clientFd >= 0 else {
+            throw LuminaError.sessionFailed("Failed to create socket: \(errno)")
+        }
+
+        var addr = sockaddr_un()
+        addr.sun_family = sa_family_t(AF_UNIX)
+        let pathStr = paths.socket.path
+        let pathBytes = pathStr.utf8CString
+        withUnsafeMutablePointer(to: &addr.sun_path) { ptr in
+            ptr.withMemoryRebound(to: CChar.self, capacity: 104) { dest in
+                pathBytes.withUnsafeBufferPointer { src in
+                    let count = min(src.count, 104)
+                    dest.update(from: src.baseAddress!, count: count)
+                }
+            }
+        }
+
+        let connectResult = withUnsafePointer(to: &addr) { ptr in
+            ptr.withMemoryRebound(to: sockaddr.self, capacity: 1) { sockPtr in
+                Darwin.connect(clientFd, sockPtr, socklen_t(MemoryLayout<sockaddr_un>.size))
+            }
+        }
+        guard connectResult == 0 else {
+            Darwin.close(clientFd)
+            clientFd = -1
+            // Socket exists but can't connect — session may be dead
+            if !paths.isAlive() {
+                paths.cleanup()
+                throw LuminaError.sessionDead(sid)
+            }
+            throw LuminaError.sessionFailed("Failed to connect to session \(sid): \(errno)")
+        }
+
+        readHandle = FileHandle(fileDescriptor: clientFd, closeOnDealloc: false)
+        writeHandle = FileHandle(fileDescriptor: clientFd, closeOnDealloc: false)
+    }
+
+    /// Send a request to the session server.
+    public func send(_ request: SessionRequest) throws {
+        guard let handle = writeHandle else {
+            throw LuminaError.connectionFailed
+        }
+        let data = try SessionProtocol.encode(request)
+        handle.write(data)
+    }
+
+    /// Read one response from the session server.
+    public func receive() throws -> SessionResponse {
+        guard let handle = readHandle else {
+            throw LuminaError.connectionFailed
+        }
+        var buffer = Data()
+        while true {
+            let chunk = handle.availableData
+            if chunk.isEmpty {
+                throw LuminaError.connectionFailed
+            }
+            buffer.append(chunk)
+            if buffer.count > SessionProtocol.maxMessageSize {
+                throw LuminaError.protocolError("Session response exceeds 64KB")
+            }
+            if buffer.firstIndex(of: UInt8(ascii: "\n")) != nil {
+                return try SessionProtocol.decodeResponse(buffer)
+            }
+        }
+    }
+
+    /// Execute a command and yield all responses until exit or error.
+    public func exec(
+        cmd: String,
+        timeout: Int = 60,
+        env: [String: String] = [:]
+    ) throws -> [SessionResponse] {
+        try send(.exec(cmd: cmd, timeout: timeout, env: env))
+        var responses: [SessionResponse] = []
+        while true {
+            let response = try receive()
+            responses.append(response)
+            switch response {
+            case .exit, .error:
+                return responses
+            default:
+                continue
+            }
+        }
+    }
+
+    /// Disconnect from the session.
+    public func disconnect() {
+        if clientFd >= 0 {
+            Darwin.close(clientFd)
+            clientFd = -1
+        }
+        readHandle = nil
+        writeHandle = nil
+    }
+
+    deinit {
+        disconnect()
+    }
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `swift test --filter SessionClientTests 2>&1 | tail -5`
+Expected: Both tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Sources/Lumina/SessionClient.swift Tests/LuminaTests/SessionClientTests.swift
+git commit -m "feat: add SessionClient for connecting to session Unix sockets"
+```
+
+---
+
+### Task 5: Session CLI commands
+
+**Files:**
+- Modify: `Sources/lumina-cli/main.swift`
+- Create: `Sources/lumina-cli/SessionProcess.swift`
+
+This task adds the CLI subcommands (`session start/stop/list`, `exec`) and the background session process entry point.
+
+- [ ] **Step 1: Add session subcommands to CLI**
+
+Add to `LuminaCLI.configuration.subcommands` in `Sources/lumina-cli/main.swift`:
+
+```swift
+static let configuration = CommandConfiguration(
+    commandName: "lumina",
+    abstract: "Native Apple Workload Runtime for Agents — subprocess.run() for virtual machines.",
+    version: "0.2.2",
+    subcommands: [Run.self, Pull.self, Images.self, Clean.self,
+                  Session.self, Exec.self]
+)
+```
+
+Add the `Session` command group and `Exec` command after the existing `Clean` struct:
+
+```swift
+// MARK: - Session
+
+struct Session: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(
+        abstract: "Manage persistent VM sessions",
+        subcommands: [SessionStart.self, SessionStop.self, SessionList.self]
+    )
+}
+
+struct SessionStart: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(commandName: "start", abstract: "Start a new persistent session")
+
+    @Option(name: .long, help: "Image to boot from")
+    var image: String = "default"
+
+    @Option(name: .long, help: "Number of CPU cores")
+    var cpus: Int = 2
+
+    @Option(name: .long, help: "Memory (e.g. 512MB, 1GB)")
+    var memory: String = "512MB"
+
+    @Option(name: .long, help: "Volume to mount (name:guest_path, repeatable)")
+    var volume: [String] = []
+
+    func run() async throws {
+        // Auto-pull image if not present
+        let puller = ImagePuller()
+        if !puller.imageExists() {
+            FileHandle.standardError.write(Data("Image not found. Pulling default image...\n".utf8))
+            do {
+                try await puller.pull { msg in
+                    FileHandle.standardError.write(Data("\(msg)\n".utf8))
+                }
+            } catch {
+                FileHandle.standardError.write(Data("lumina: auto-pull failed: \(error)\n".utf8))
+                throw ExitCode.failure
+            }
+        }
+
+        guard let parsedMemory = parseMemory(memory) else {
+            FileHandle.standardError.write(Data("lumina: invalid memory '\(memory)'\n".utf8))
+            throw ExitCode.failure
+        }
+
+        var parsedVolumes: [VolumeMount] = []
+        for spec in volume {
+            guard let colonIndex = spec.firstIndex(of: ":") else {
+                FileHandle.standardError.write(Data("lumina: invalid --volume '\(spec)'. Use name:guest_path format\n".utf8))
+                throw ExitCode.failure
+            }
+            let name = String(spec[spec.startIndex..<colonIndex])
+            let guestPath = String(spec[spec.index(after: colonIndex)...])
+            parsedVolumes.append(VolumeMount(name: name, guestPath: guestPath))
+        }
+
+        let sid = UUID().uuidString
+        let execPath = ProcessInfo.processInfo.arguments[0]
+
+        // Spawn background session process
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: execPath)
+        process.arguments = [
+            "_session-serve",
+            "--sid", sid,
+            "--image", image,
+            "--cpus", String(cpus),
+            "--memory", String(parsedMemory),
+        ]
+        for v in parsedVolumes {
+            process.arguments! += ["--volume", "\(v.name):\(v.guestPath)"]
+        }
+
+        // Detach from terminal
+        process.standardInput = FileHandle.nullDevice
+        process.standardOutput = FileHandle.nullDevice
+        process.standardError = FileHandle.nullDevice
+
+        do {
+            try process.run()
+        } catch {
+            FileHandle.standardError.write(Data("lumina: failed to start session: \(error)\n".utf8))
+            throw ExitCode.failure
+        }
+
+        // Wait for the socket to appear (session process boots VM)
+        let paths = SessionPaths(sid: sid)
+        let deadline = ContinuousClock.now + .seconds(30)
+        while ContinuousClock.now < deadline {
+            if FileManager.default.fileExists(atPath: paths.socket.path) {
+                break
+            }
+            try await Task.sleep(nanoseconds: 100_000_000) // 100ms
+        }
+
+        guard FileManager.default.fileExists(atPath: paths.socket.path) else {
+            FileHandle.standardError.write(Data("lumina: session failed to start within 30s\n".utf8))
+            throw ExitCode.failure
+        }
+
+        // Output session ID
+        let format = resolveOutputFormat(textFlag: false)
+        switch format {
+        case .json:
+            let output = try JSONSerialization.data(withJSONObject: ["sid": sid], options: [.sortedKeys])
+            print(String(data: output, encoding: .utf8)!)
+        case .text:
+            print(sid)
+        }
+    }
+}
+
+struct SessionStop: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(commandName: "stop", abstract: "Stop a running session")
+
+    @Argument(help: "Session ID")
+    var sid: String
+
+    func run() async throws {
+        let client = SessionClient()
+        do {
+            try client.connect(sid: sid)
+            try client.send(.shutdown)
+            _ = try? client.receive()
+            client.disconnect()
+        } catch let error as LuminaError {
+            switch error {
+            case .sessionNotFound:
+                FileHandle.standardError.write(Data("lumina: session '\(sid)' not found\n".utf8))
+            case .sessionDead:
+                FileHandle.standardError.write(Data("lumina: session '\(sid)' is dead (cleaned up)\n".utf8))
+            default:
+                FileHandle.standardError.write(Data("lumina: \(error)\n".utf8))
+            }
+            throw ExitCode.failure
+        }
+    }
+}
+
+struct SessionList: ParsableCommand {
+    static let configuration = CommandConfiguration(commandName: "list", abstract: "List active sessions")
+
+    @Flag(name: .long, help: "Force human-readable text output")
+    var text = false
+
+    func run() throws {
+        let sessions = SessionPaths.listAll()
+        let format = resolveOutputFormat(textFlag: text)
+        switch format {
+        case .json:
+            let encoder = JSONEncoder()
+            encoder.outputFormatting = .sortedKeys
+            encoder.dateEncodingStrategy = .iso8601
+            if let data = try? encoder.encode(sessions),
+               let str = String(data: data, encoding: .utf8) {
+                print(str)
+            }
+        case .text:
+            if sessions.isEmpty {
+                print("No active sessions.")
+            } else {
+                for s in sessions {
+                    let status = s.status == .running ? "running" : "dead"
+                    print("\(s.sid)\t\(s.image)\t\(status)")
+                }
+            }
+        }
+    }
+}
+
+// MARK: - Exec
+
+struct Exec: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(abstract: "Execute a command in a running session")
+
+    @Argument(help: "Session ID")
+    var sid: String
+
+    @Argument(help: "Command to run")
+    var command: String
+
+    @Flag(name: .long, help: "Stream output in real time")
+    var stream = false
+
+    @Flag(name: .long, help: "Force human-readable text output")
+    var text = false
+
+    @Option(name: .long, help: "Timeout (e.g. 30s, 5m)")
+    var timeout: String = "60s"
+
+    @Option(name: [.short, .long], help: "Environment variable (KEY=VAL, repeatable)")
+    var env: [String] = []
+
+    @Option(name: .long, help: "Copy file into VM (local:remote, repeatable)")
+    var copy: [String] = []
+
+    @Option(name: .long, help: "Download file from VM (remote:local, repeatable)")
+    var download: [String] = []
+
+    func run() async throws {
+        guard let parsedTimeout = parseDuration(timeout) else {
+            FileHandle.standardError.write(Data("lumina: invalid timeout '\(timeout)'\n".utf8))
+            throw ExitCode.failure
+        }
+        let timeoutSecs = Int(parsedTimeout.components.seconds)
+
+        var parsedEnv: [String: String] = [:]
+        for pair in env {
+            guard let eqIndex = pair.firstIndex(of: "=") else {
+                FileHandle.standardError.write(Data("lumina: invalid env '\(pair)'. Use KEY=VAL\n".utf8))
+                throw ExitCode.failure
+            }
+            parsedEnv[String(pair[..<eqIndex])] = String(pair[pair.index(after: eqIndex)...])
+        }
+
+        let client = SessionClient()
+        do {
+            try client.connect(sid: sid)
+        } catch let error as LuminaError {
+            switch error {
+            case .sessionNotFound:
+                FileHandle.standardError.write(Data("lumina: session '\(sid)' not found\n".utf8))
+            case .sessionDead:
+                FileHandle.standardError.write(Data("lumina: session '\(sid)' is dead (cleaned up)\n".utf8))
+            default:
+                FileHandle.standardError.write(Data("lumina: \(error)\n".utf8))
+            }
+            throw ExitCode.failure
+        }
+        defer { client.disconnect() }
+
+        // Handle file uploads before exec
+        for spec in copy {
+            guard let colonIndex = spec.firstIndex(of: ":") else {
+                FileHandle.standardError.write(Data("lumina: invalid --copy '\(spec)'\n".utf8))
+                throw ExitCode.failure
+            }
+            let localStr = String(spec[..<colonIndex])
+            let remote = String(spec[spec.index(after: colonIndex)...])
+            try client.send(.upload(localPath: localStr, remotePath: remote))
+            let resp = try client.receive()
+            if case .error(let msg) = resp {
+                FileHandle.standardError.write(Data("lumina: upload failed: \(msg)\n".utf8))
+                throw ExitCode.failure
+            }
+        }
+
+        // Execute
+        let format = resolveOutputFormat(textFlag: text)
+        try client.send(.exec(cmd: command, timeout: timeoutSecs, env: parsedEnv))
+
+        while true {
+            let response = try client.receive()
+            switch response {
+            case .output(let outputStream, let data):
+                switch format {
+                case .json:
+                    printNDJSON(["stream": outputStream.rawValue, "data": data])
+                case .text:
+                    if outputStream == .stdout {
+                        print(data, terminator: "")
+                    } else {
+                        FileHandle.standardError.write(Data(data.utf8))
+                    }
+                }
+            case .exit(let code, let durationMs):
+                switch format {
+                case .json:
+                    printNDJSON(["exit_code": Int(code), "duration_ms": durationMs])
+                case .text:
+                    break
+                }
+
+                // Handle file downloads after exec
+                for spec in download {
+                    guard let colonIndex = spec.firstIndex(of: ":") else { continue }
+                    let remote = String(spec[..<colonIndex])
+                    let localStr = String(spec[spec.index(after: colonIndex)...])
+                    try client.send(.download(remotePath: remote, localPath: localStr))
+                    let dlResp = try client.receive()
+                    if case .error(let msg) = dlResp {
+                        FileHandle.standardError.write(Data("lumina: download failed: \(msg)\n".utf8))
+                    }
+                }
+
+                if code != 0 { throw ExitCode(code) }
+                return
+            case .error(let message):
+                FileHandle.standardError.write(Data("lumina: \(message)\n".utf8))
+                throw ExitCode.failure
+            default:
+                continue
+            }
+        }
+    }
+}
+```
+
+- [ ] **Step 2: Add the hidden `_session-serve` subcommand**
+
+Create `Sources/lumina-cli/SessionProcess.swift`:
+
+```swift
+// Sources/lumina-cli/SessionProcess.swift
+import ArgumentParser
+import Foundation
+import Lumina
+
+/// Hidden subcommand spawned by `session start`. Boots a VM, starts a
+/// SessionServer on a Unix socket, and runs until shutdown or signal.
+struct SessionServe: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "_session-serve",
+        shouldDisplay: false, // hidden from help
+        abstract: "Internal: serve a session (spawned by session start)"
+    )
+
+    @Option(help: "Session ID")
+    var sid: String
+
+    @Option(help: "Image name")
+    var image: String = "default"
+
+    @Option(help: "CPU count")
+    var cpus: Int = 2
+
+    @Option(help: "Memory in bytes")
+    var memory: UInt64 = 512 * 1024 * 1024
+
+    @Option(help: "Volume mount (name:guest_path, repeatable)")
+    var volume: [String] = []
+
+    func run() async throws {
+        installSignalHandlers()
+
+        let paths = SessionPaths(sid: sid)
+
+        // Parse volumes into MountPoints by resolving through VolumeStore
+        let volumeStore = VolumeStore()
+        var mounts: [MountPoint] = []
+        for spec in volume {
+            guard let colonIndex = spec.firstIndex(of: ":") else { continue }
+            let name = String(spec[spec.startIndex..<colonIndex])
+            let guestPath = String(spec[spec.index(after: colonIndex)...])
+            guard let hostDir = volumeStore.resolve(name: name) else {
+                FileHandle.standardError.write(Data("lumina: volume '\(name)' not found\n".utf8))
+                throw ExitCode.failure
+            }
+            mounts.append(MountPoint(hostPath: hostDir, guestPath: guestPath))
+        }
+
+        // Boot VM
+        let vmOptions = VMOptions(
+            memory: memory,
+            cpuCount: cpus,
+            image: image,
+            mounts: mounts
+        )
+        let vm = VM(options: vmOptions)
+
+        do {
+            try await vm.bootResult().get()
+        } catch {
+            FileHandle.standardError.write(Data("lumina: session boot failed: \(error)\n".utf8))
+            throw ExitCode.failure
+        }
+
+        // Write session metadata
+        let info = SessionInfo(
+            sid: sid,
+            pid: ProcessInfo.processInfo.processIdentifier,
+            image: image,
+            cpuCount: cpus,
+            memory: memory,
+            created: Date(),
+            status: .running
+        )
+        do {
+            try paths.writeMeta(info)
+        } catch {
+            await vm.shutdown()
+            throw ExitCode.failure
+        }
+
+        // Start session server
+        let server = SessionServer(socketPath: paths.socket)
+        do {
+            try server.bind()
+        } catch {
+            await vm.shutdown()
+            paths.cleanup()
+            throw ExitCode.failure
+        }
+
+        // Serve until shutdown
+        await server.serve(vm: vm)
+
+        // Cleanup
+        paths.cleanup()
+    }
+}
+```
+
+Add `SessionServe` to the subcommands list in `LuminaCLI`:
+
+```swift
+subcommands: [Run.self, Pull.self, Images.self, Clean.self,
+              Session.self, Exec.self, SessionServe.self]
+```
+
+- [ ] **Step 3: Build to verify compilation**
+
+Run: `swift build 2>&1 | tail -10`
+Expected: Build succeeds. (VolumeStore doesn't exist yet — we'll stub it in the next phase. For now, comment out the VolumeStore usage in SessionProcess.swift and replace with a TODO, or create a minimal VolumeStore stub.)
+
+Note: If build fails due to missing `VolumeStore`, create a minimal stub:
+
+```swift
+// Sources/Lumina/VolumeStore.swift (stub — full implementation in Task 9)
+import Foundation
+
+public struct VolumeStore: Sendable {
+    public init() {}
+    public func resolve(name: String) -> URL? { nil }
+}
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add Sources/lumina-cli/main.swift Sources/lumina-cli/SessionProcess.swift Sources/Lumina/VolumeStore.swift
+git commit -m "feat: add session CLI commands (start, stop, list, exec)"
+```
+
+---
+
+## Phase 2: Custom Images
+
+### Task 6: ImageStore.create with staging-dir atomicity
+
+**Files:**
+- Modify: `Sources/Lumina/ImageStore.swift`
+- Modify: `Sources/Lumina/Types.swift`
+- Test: `Tests/LuminaTests/ImageStoreTests.swift`
+
+- [ ] **Step 1: Write failing tests for image creation**
+
+Add to `Tests/LuminaTests/ImageStoreTests.swift`:
+
+```swift
+@Test func imageCreateAndInspect() throws {
+    let tmpDir = FileManager.default.temporaryDirectory.appendingPathComponent("lumina-imgtest-\(UUID().uuidString)")
+    try FileManager.default.createDirectory(at: tmpDir, withIntermediateDirectories: true)
+    defer { try? FileManager.default.removeItem(at: tmpDir) }
+
+    let store = ImageStore(baseDir: tmpDir)
+
+    // Create a fake base image
+    let baseDir = tmpDir.appendingPathComponent("default")
+    try FileManager.default.createDirectory(at: baseDir, withIntermediateDirectories: true)
+    try Data("kernel".utf8).write(to: baseDir.appendingPathComponent("vmlinuz"))
+    try Data("initrd".utf8).write(to: baseDir.appendingPathComponent("initrd"))
+    try Data("rootfs".utf8).write(to: baseDir.appendingPathComponent("rootfs.img"))
+    try Data("agent".utf8).write(to: baseDir.appendingPathComponent("lumina-agent"))
+    let modulesDir = baseDir.appendingPathComponent("modules")
+    try FileManager.default.createDirectory(at: modulesDir, withIntermediateDirectories: true)
+
+    // Create a modified rootfs (simulates what DiskClone.rootfs would contain)
+    let modifiedRootfs = tmpDir.appendingPathComponent("modified-rootfs.img")
+    try Data("modified rootfs".utf8).write(to: modifiedRootfs)
+
+    // Create image
+    try store.createImage(
+        name: "python",
+        from: "default",
+        rootfsSource: modifiedRootfs,
+        command: "apk add python3"
+    )
+
+    // Verify image exists
+    let names = store.list()
+    #expect(names.contains("python"))
+
+    // Verify inspect
+    let info = try store.inspect(name: "python")
+    #expect(info.name == "python")
+    #expect(info.base == "default")
+    #expect(info.command == "apk add python3")
+
+    // Verify rootfs is a copy, not a symlink
+    let pythonRootfs = tmpDir.appendingPathComponent("python/rootfs.img")
+    let rootfsContent = try String(contentsOf: pythonRootfs, encoding: .utf8)
+    #expect(rootfsContent == "modified rootfs")
+}
+
+@Test func imageRemoveWithDependents() throws {
+    let tmpDir = FileManager.default.temporaryDirectory.appendingPathComponent("lumina-imgtest-\(UUID().uuidString)")
+    try FileManager.default.createDirectory(at: tmpDir, withIntermediateDirectories: true)
+    defer { try? FileManager.default.removeItem(at: tmpDir) }
+
+    let store = ImageStore(baseDir: tmpDir)
+
+    // Create base + derived images manually
+    let baseDir = tmpDir.appendingPathComponent("default")
+    try FileManager.default.createDirectory(at: baseDir, withIntermediateDirectories: true)
+    try Data("k".utf8).write(to: baseDir.appendingPathComponent("vmlinuz"))
+    try Data("i".utf8).write(to: baseDir.appendingPathComponent("initrd"))
+    try Data("r".utf8).write(to: baseDir.appendingPathComponent("rootfs.img"))
+
+    let pythonDir = tmpDir.appendingPathComponent("python")
+    try FileManager.default.createDirectory(at: pythonDir, withIntermediateDirectories: true)
+    try Data("r2".utf8).write(to: pythonDir.appendingPathComponent("rootfs.img"))
+    let meta = ImageMeta(base: "default", command: "apk add python3", created: Date())
+    try JSONEncoder().encode(meta).write(to: pythonDir.appendingPathComponent("meta.json"))
+
+    // Should refuse to remove default (python depends on it)
+    #expect(throws: LuminaError.self) {
+        try store.removeImage(name: "default")
+    }
+
+    // Should allow removing python (no dependents)
+    try store.removeImage(name: "python")
+    #expect(!store.list().contains("python"))
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `swift test --filter ImageStoreTests 2>&1 | head -20`
+Expected: Compilation errors — new methods don't exist.
+
+- [ ] **Step 3: Add ImageMeta and ImageInfo types**
+
+Add to `Sources/Lumina/Types.swift`:
+
+```swift
+// MARK: - Image Types
+
+public struct ImageInfo: Sendable {
+    public let name: String
+    public let base: String?
+    public let command: String?
+    public let created: Date
+    public let sizeBytes: UInt64
+}
+
+public struct ImageMeta: Sendable, Codable {
+    public let base: String?
+    public let command: String?
+    public let created: Date
+
+    public init(base: String?, command: String?, created: Date) {
+        self.base = base
+        self.command = command
+        self.created = created
+    }
+}
+```
+
+- [ ] **Step 4: Implement ImageStore extensions**
+
+Add to `Sources/Lumina/ImageStore.swift`:
+
+```swift
+    /// Create a new named image from a base image and a modified rootfs.
+    /// Uses staging-dir + atomic rename for crash safety.
+    public func createImage(
+        name: String,
+        from base: String,
+        rootfsSource: URL,
+        command: String
+    ) throws {
+        let fm = FileManager.default
+
+        // Validate base exists
+        let baseDir = baseDir.appendingPathComponent(base)
+        guard fm.fileExists(atPath: baseDir.appendingPathComponent("rootfs.img").path) else {
+            throw LuminaError.imageNotFound(base)
+        }
+
+        // Staging dir for atomic creation
+        let stagingId = UUID().uuidString
+        let stagingDir = baseDir.deletingLastPathComponent().appendingPathComponent(".tmp-\(stagingId)")
+
+        do {
+            try fm.createDirectory(at: stagingDir, withIntermediateDirectories: true)
+
+            // Copy modified rootfs
+            try fm.copyItem(at: rootfsSource, to: stagingDir.appendingPathComponent("rootfs.img"))
+
+            // Symlink shared assets from base
+            for asset in ["vmlinuz", "initrd", "lumina-agent"] {
+                let source = baseDir.appendingPathComponent(asset)
+                if fm.fileExists(atPath: source.path) {
+                    try fm.createSymbolicLink(
+                        at: stagingDir.appendingPathComponent(asset),
+                        withDestinationURL: source
+                    )
+                }
+            }
+
+            // Symlink modules directory
+            let baseModules = baseDir.appendingPathComponent("modules")
+            if fm.fileExists(atPath: baseModules.path) {
+                try fm.createSymbolicLink(
+                    at: stagingDir.appendingPathComponent("modules"),
+                    withDestinationURL: baseModules
+                )
+            }
+
+            // Write meta.json
+            let meta = ImageMeta(base: base, command: command, created: Date())
+            let metaData = try JSONEncoder().encode(meta)
+            try metaData.write(to: stagingDir.appendingPathComponent("meta.json"))
+
+            // Atomic rename to final location
+            let finalDir = self.baseDir.appendingPathComponent(name)
+            try fm.moveItem(at: stagingDir, to: finalDir)
+        } catch let error as LuminaError {
+            try? fm.removeItem(at: stagingDir)
+            throw error
+        } catch {
+            try? fm.removeItem(at: stagingDir)
+            throw LuminaError.cloneFailed(underlying: error)
+        }
+    }
+
+    /// Remove a named image. Refuses if other images depend on it.
+    public func removeImage(name: String) throws {
+        // Check for dependents
+        let allNames = list()
+        for other in allNames where other != name {
+            let metaFile = baseDir.appendingPathComponent(other).appendingPathComponent("meta.json")
+            if let data = try? Data(contentsOf: metaFile),
+               let meta = try? JSONDecoder().decode(ImageMeta.self, from: data),
+               meta.base == name {
+                throw LuminaError.sessionFailed("Cannot remove '\(name)': image '\(other)' depends on it")
+            }
+        }
+
+        let dir = baseDir.appendingPathComponent(name)
+        try FileManager.default.removeItem(at: dir)
+    }
+
+    /// Inspect an image — returns metadata and size.
+    public func inspect(name: String) throws -> ImageInfo {
+        let dir = baseDir.appendingPathComponent(name)
+        let metaFile = dir.appendingPathComponent("meta.json")
+        let rootfs = dir.appendingPathComponent("rootfs.img")
+
+        guard FileManager.default.fileExists(atPath: rootfs.path) else {
+            throw LuminaError.imageNotFound(name)
+        }
+
+        var base: String? = nil
+        var command: String? = nil
+        var created = Date()
+
+        if let data = try? Data(contentsOf: metaFile),
+           let meta = try? JSONDecoder().decode(ImageMeta.self, from: data) {
+            base = meta.base
+            command = meta.command
+            created = meta.created
+        }
+
+        let attrs = try? FileManager.default.attributesOfItem(atPath: rootfs.path)
+        let size = attrs?[.size] as? UInt64 ?? 0
+
+        return ImageInfo(name: name, base: base, command: command, created: created, sizeBytes: size)
+    }
+
+    /// Clean up staging directories left by crashed image creation attempts.
+    public func cleanStagingDirs() {
+        let fm = FileManager.default
+        guard let entries = try? fm.contentsOfDirectory(at: baseDir, includingPropertiesForKeys: nil) else { return }
+        for entry in entries where entry.lastPathComponent.hasPrefix(".tmp-") {
+            try? fm.removeItem(at: entry)
+        }
+    }
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `swift test --filter ImageStoreTests 2>&1 | tail -5`
+Expected: All image tests pass.
+
+- [ ] **Step 6: Add Lumina.createImage convenience and image CLI commands**
+
+Add to `Sources/Lumina/Lumina.swift`:
+
+```swift
+    /// Create a custom image by running a command in a disposable VM.
+    public static func createImage(
+        name: String,
+        from base: String = "default",
+        command: String,
+        options: RunOptions = .default
+    ) async throws {
+        var opts = options
+        opts.image = base
+        try await withVM(options: opts) { vm in
+            try await vm.bootResult().get()
+            let result = try await vm.execResult(command, timeout: Int(opts.timeout.components.seconds), env: opts.env).get()
+            guard result.success else {
+                throw LuminaError.sessionFailed("Image build command failed with exit code \(result.exitCode): \(result.stderr)")
+            }
+            // The VM's DiskClone rootfs is the modified disk — copy it to ImageStore
+            guard let clone = await vm.diskClone else {
+                throw LuminaError.sessionFailed("No disk clone available")
+            }
+            let store = ImageStore()
+            try store.createImage(name: name, from: base, rootfsSource: clone.rootfs, command: command)
+        }
+    }
+```
+
+Note: This requires exposing `diskClone` on the VM actor. Add a public accessor to `VM.swift`:
+
+```swift
+public var diskClone: DiskClone? { clone }
+```
+
+Add image CLI subcommands to `main.swift`:
+
+```swift
+// Update Images struct to have subcommands
+struct Images: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(
+        abstract: "Manage cached images",
+        subcommands: [ImageList.self, ImageCreate.self, ImageRemove.self, ImageInspect.self],
+        defaultSubcommand: ImageList.self
+    )
+}
+
+struct ImageList: ParsableCommand {
+    static let configuration = CommandConfiguration(commandName: "list", abstract: "List cached images")
+
+    func run() throws {
+        let store = ImageStore()
+        let names = store.list()
+        if names.isEmpty {
+            print("No images found. Run 'lumina pull' first.")
+        } else {
+            for name in names { print(name) }
+        }
+    }
+}
+
+struct ImageCreate: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(commandName: "create", abstract: "Create a custom image")
+
+    @Argument(help: "Name for the new image")
+    var name: String
+
+    @Option(name: .long, help: "Base image to build from")
+    var from: String = "default"
+
+    @Option(name: .long, help: "Command to run for setup")
+    var run runCmd: String
+
+    func run() async throws {
+        FileHandle.standardError.write(Data("Creating image '\(name)' from '\(from)'...\n".utf8))
+        do {
+            try await Lumina.createImage(name: name, from: from, command: runCmd)
+            print("Image '\(name)' created successfully.")
+        } catch {
+            FileHandle.standardError.write(Data("lumina: image create failed: \(error)\n".utf8))
+            throw ExitCode.failure
+        }
+    }
+}
+
+struct ImageRemove: ParsableCommand {
+    static let configuration = CommandConfiguration(commandName: "remove", abstract: "Remove a cached image")
+
+    @Argument(help: "Image name to remove")
+    var name: String
+
+    func run() throws {
+        let store = ImageStore()
+        do {
+            try store.removeImage(name: name)
+            print("Image '\(name)' removed.")
+        } catch {
+            FileHandle.standardError.write(Data("lumina: \(error)\n".utf8))
+            throw ExitCode.failure
+        }
+    }
+}
+
+struct ImageInspect: ParsableCommand {
+    static let configuration = CommandConfiguration(commandName: "inspect", abstract: "Show image details")
+
+    @Argument(help: "Image name")
+    var name: String
+
+    func run() throws {
+        let store = ImageStore()
+        let info = try store.inspect(name: name)
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.sortedKeys, .prettyPrinted]
+        encoder.dateEncodingStrategy = .iso8601
+        // Manual output since ImageInfo isn't Codable
+        let dict: [String: Any] = [
+            "name": info.name,
+            "base": info.base ?? "none",
+            "command": info.command ?? "none",
+            "size_bytes": info.sizeBytes,
+            "created": ISO8601DateFormatter().string(from: info.created)
+        ]
+        if let data = try? JSONSerialization.data(withJSONObject: dict, options: [.sortedKeys, .prettyPrinted]),
+           let str = String(data: data, encoding: .utf8) {
+            print(str)
+        }
+    }
+}
+```
+
+- [ ] **Step 7: Build and test**
+
+Run: `swift build 2>&1 | tail -10`
+Expected: Build succeeds.
+
+Run: `swift test --filter ImageStoreTests 2>&1 | tail -5`
+Expected: All tests pass.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add Sources/Lumina/ImageStore.swift Sources/Lumina/Types.swift Sources/Lumina/Lumina.swift Sources/Lumina/VM.swift Sources/lumina-cli/main.swift
+git commit -m "feat: add custom image creation with staging-dir atomicity"
+```
+
+---
+
+## Phase 3: Volumes
+
+### Task 7: VolumeStore
+
+**Files:**
+- Modify: `Sources/Lumina/VolumeStore.swift` (replace stub)
+- Test: `Tests/LuminaTests/VolumeStoreTests.swift`
+
+- [ ] **Step 1: Write failing tests**
+
+```swift
+// Tests/LuminaTests/VolumeStoreTests.swift
+import Foundation
+import Testing
+@testable import Lumina
+
+@Test func volumeCreateAndResolve() throws {
+    let tmpDir = FileManager.default.temporaryDirectory.appendingPathComponent("lumina-voltest-\(UUID().uuidString)")
+    defer { try? FileManager.default.removeItem(at: tmpDir) }
+
+    let store = VolumeStore(baseDir: tmpDir)
+    try store.create(name: "pycache")
+
+    let resolved = store.resolve(name: "pycache")
+    #expect(resolved != nil)
+    #expect(resolved!.path.hasSuffix("/pycache/data"))
+
+    var isDir: ObjCBool = false
+    #expect(FileManager.default.fileExists(atPath: resolved!.path, isDirectory: &isDir))
+    #expect(isDir.boolValue)
+}
+
+@Test func volumeList() throws {
+    let tmpDir = FileManager.default.temporaryDirectory.appendingPathComponent("lumina-voltest-\(UUID().uuidString)")
+    defer { try? FileManager.default.removeItem(at: tmpDir) }
+
+    let store = VolumeStore(baseDir: tmpDir)
+    try store.create(name: "cache")
+    try store.create(name: "data")
+
+    let names = store.list()
+    #expect(names.contains("cache"))
+    #expect(names.contains("data"))
+}
+
+@Test func volumeRemove() throws {
+    let tmpDir = FileManager.default.temporaryDirectory.appendingPathComponent("lumina-voltest-\(UUID().uuidString)")
+    defer { try? FileManager.default.removeItem(at: tmpDir) }
+
+    let store = VolumeStore(baseDir: tmpDir)
+    try store.create(name: "temp")
+    try store.remove(name: "temp")
+
+    #expect(store.resolve(name: "temp") == nil)
+    #expect(!store.list().contains("temp"))
+}
+
+@Test func volumeInspect() throws {
+    let tmpDir = FileManager.default.temporaryDirectory.appendingPathComponent("lumina-voltest-\(UUID().uuidString)")
+    defer { try? FileManager.default.removeItem(at: tmpDir) }
+
+    let store = VolumeStore(baseDir: tmpDir)
+    try store.create(name: "test")
+
+    let info = try store.inspect(name: "test")
+    #expect(info.name == "test")
+    #expect(info.sizeBytes == 0)
+}
+
+@Test func volumeResolveMissing() {
+    let tmpDir = FileManager.default.temporaryDirectory.appendingPathComponent("lumina-voltest-\(UUID().uuidString)")
+    let store = VolumeStore(baseDir: tmpDir)
+    #expect(store.resolve(name: "nonexistent") == nil)
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `swift test --filter VolumeStoreTests 2>&1 | head -20`
+Expected: Compilation errors.
+
+- [ ] **Step 3: Implement full VolumeStore**
+
+Replace the stub `Sources/Lumina/VolumeStore.swift`:
+
+```swift
+// Sources/Lumina/VolumeStore.swift
+import Foundation
+
+public struct VolumeInfo: Sendable {
+    public let name: String
+    public let created: Date
+    public let lastUsed: Date
+    public let sizeBytes: UInt64
+}
+
+struct VolumeMeta: Codable {
+    var created: Date
+    var lastUsed: Date
+}
+
+public struct VolumeStore: Sendable {
+    public let baseDir: URL
+
+    public static let defaultBaseDir: URL = {
+        FileManager.default.homeDirectoryForCurrentUser
+            .appendingPathComponent(".lumina/volumes")
+    }()
+
+    public init(baseDir: URL = VolumeStore.defaultBaseDir) {
+        self.baseDir = baseDir
+    }
+
+    public func create(name: String) throws {
+        let dir = baseDir.appendingPathComponent(name)
+        let dataDir = dir.appendingPathComponent("data")
+        try FileManager.default.createDirectory(at: dataDir, withIntermediateDirectories: true)
+
+        let meta = VolumeMeta(created: Date(), lastUsed: Date())
+        let data = try JSONEncoder().encode(meta)
+        try data.write(to: dir.appendingPathComponent("meta.json"))
+    }
+
+    public func resolve(name: String) -> URL? {
+        let dataDir = baseDir.appendingPathComponent(name).appendingPathComponent("data")
+        var isDir: ObjCBool = false
+        guard FileManager.default.fileExists(atPath: dataDir.path, isDirectory: &isDir),
+              isDir.boolValue else {
+            return nil
+        }
+        return dataDir
+    }
+
+    public func remove(name: String) throws {
+        let dir = baseDir.appendingPathComponent(name)
+        try FileManager.default.removeItem(at: dir)
+    }
+
+    public func list() -> [String] {
+        guard let entries = try? FileManager.default.contentsOfDirectory(
+            at: baseDir,
+            includingPropertiesForKeys: [.isDirectoryKey]
+        ) else { return [] }
+        return entries
+            .filter { (try? $0.resourceValues(forKeys: [.isDirectoryKey]).isDirectory) == true }
+            .map { $0.lastPathComponent }
+            .sorted()
+    }
+
+    public func inspect(name: String) throws -> VolumeInfo {
+        let dir = baseDir.appendingPathComponent(name)
+        let metaFile = dir.appendingPathComponent("meta.json")
+
+        guard FileManager.default.fileExists(atPath: dir.path) else {
+            throw LuminaError.sessionFailed("Volume '\(name)' not found")
+        }
+
+        var created = Date()
+        var lastUsed = Date()
+        if let data = try? Data(contentsOf: metaFile),
+           let meta = try? JSONDecoder().decode(VolumeMeta.self, from: data) {
+            created = meta.created
+            lastUsed = meta.lastUsed
+        }
+
+        // Calculate directory size
+        let dataDir = dir.appendingPathComponent("data")
+        let size = directorySize(dataDir)
+
+        return VolumeInfo(name: name, created: created, lastUsed: lastUsed, sizeBytes: size)
+    }
+
+    /// Update last_used timestamp when a volume is mounted.
+    public func touch(name: String) {
+        let metaFile = baseDir.appendingPathComponent(name).appendingPathComponent("meta.json")
+        guard let data = try? Data(contentsOf: metaFile),
+              var meta = try? JSONDecoder().decode(VolumeMeta.self, from: data) else { return }
+        meta.lastUsed = Date()
+        if let updated = try? JSONEncoder().encode(meta) {
+            try? updated.write(to: metaFile)
+        }
+    }
+
+    private func directorySize(_ url: URL) -> UInt64 {
+        let fm = FileManager.default
+        guard let enumerator = fm.enumerator(at: url, includingPropertiesForKeys: [.fileSizeKey]) else { return 0 }
+        var total: UInt64 = 0
+        for case let fileURL as URL in enumerator {
+            if let size = try? fileURL.resourceValues(forKeys: [.fileSizeKey]).fileSize {
+                total += UInt64(size)
+            }
+        }
+        return total
+    }
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `swift test --filter VolumeStoreTests 2>&1 | tail -5`
+Expected: All 5 tests pass.
+
+- [ ] **Step 5: Add volume CLI subcommands and --volume flag**
+
+Add to `Sources/lumina-cli/main.swift`:
+
+```swift
+// MARK: - Volume
+
+struct Volume: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(
+        abstract: "Manage persistent volumes",
+        subcommands: [VolumeCreate.self, VolumeList.self, VolumeRemove.self, VolumeInspect.self]
+    )
+}
+
+struct VolumeCreate: ParsableCommand {
+    static let configuration = CommandConfiguration(commandName: "create", abstract: "Create a named volume")
+
+    @Argument(help: "Volume name")
+    var name: String
+
+    func run() throws {
+        let store = VolumeStore()
+        try store.create(name: name)
+        print("Volume '\(name)' created.")
+    }
+}
+
+struct VolumeList: ParsableCommand {
+    static let configuration = CommandConfiguration(commandName: "list", abstract: "List volumes")
+
+    func run() throws {
+        let store = VolumeStore()
+        let names = store.list()
+        if names.isEmpty {
+            print("No volumes.")
+        } else {
+            for name in names { print(name) }
+        }
+    }
+}
+
+struct VolumeRemove: ParsableCommand {
+    static let configuration = CommandConfiguration(commandName: "remove", abstract: "Remove a volume")
+
+    @Argument(help: "Volume name")
+    var name: String
+
+    func run() throws {
+        let store = VolumeStore()
+        try store.remove(name: name)
+        print("Volume '\(name)' removed.")
+    }
+}
+
+struct VolumeInspect: ParsableCommand {
+    static let configuration = CommandConfiguration(commandName: "inspect", abstract: "Show volume details")
+
+    @Argument(help: "Volume name")
+    var name: String
+
+    func run() throws {
+        let store = VolumeStore()
+        let info = try store.inspect(name: name)
+        let dict: [String: Any] = [
+            "name": info.name,
+            "size_bytes": info.sizeBytes,
+            "created": ISO8601DateFormatter().string(from: info.created),
+            "last_used": ISO8601DateFormatter().string(from: info.lastUsed)
+        ]
+        if let data = try? JSONSerialization.data(withJSONObject: dict, options: [.sortedKeys, .prettyPrinted]),
+           let str = String(data: data, encoding: .utf8) {
+            print(str)
+        }
+    }
+}
+```
+
+Add `Volume.self` to the subcommands list. Also add `--volume` flag to the `Run` command to resolve volumes into MountPoints:
+
+In the `Run.run()` method, add volume resolution after parsing mounts:
+
+```swift
+// Resolve --volume flags (name:guest_path → host_path:guest_path)
+let volumeStore = VolumeStore()
+for spec in volumeSpecs {
+    guard let colonIndex = spec.firstIndex(of: ":") else {
+        FileHandle.standardError.write(Data("lumina: invalid --volume '\(spec)'. Use name:guest_path\n".utf8))
+        throw ExitCode.failure
+    }
+    let name = String(spec[..<colonIndex])
+    let guestPath = String(spec[spec.index(after: colonIndex)...])
+    guard let hostDir = volumeStore.resolve(name: name) else {
+        FileHandle.standardError.write(Data("lumina: volume '\(name)' not found\n".utf8))
+        throw ExitCode.failure
+    }
+    volumeStore.touch(name: name)
+    parsedMounts.append(MountPoint(hostPath: hostDir, guestPath: guestPath))
+}
+```
+
+- [ ] **Step 6: Build and test**
+
+Run: `swift build 2>&1 | tail -10 && swift test --filter VolumeStoreTests 2>&1 | tail -5`
+Expected: Build succeeds, all volume tests pass.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add Sources/Lumina/VolumeStore.swift Tests/LuminaTests/VolumeStoreTests.swift Sources/lumina-cli/main.swift
+git commit -m "feat: add VolumeStore and volume CLI commands"
+```
+
+---
+
+## Phase 4: Networking
+
+### Task 8: NetworkSwitch (SOCK_DGRAM relay)
+
+**Files:**
+- Create: `Sources/Lumina/NetworkSwitch.swift`
+- Test: `Tests/LuminaTests/NetworkSwitchTests.swift`
+
+- [ ] **Step 1: Write failing tests for NetworkSwitch**
+
+```swift
+// Tests/LuminaTests/NetworkSwitchTests.swift
+import Foundation
+import Testing
+@testable import Lumina
+
+@Test func networkSwitchCreatePort() throws {
+    let sw = NetworkSwitch()
+    let port = try sw.createPort()
+    #expect(port.vmFd >= 0)
+    #expect(port.switchFd >= 0)
+    sw.close()
+}
+
+@Test func networkSwitchRelayFrames() throws {
+    let sw = NetworkSwitch()
+    let port1 = try sw.createPort()
+    let port2 = try sw.createPort()
+
+    sw.startRelay()
+
+    // Write a frame to port1's switch-side fd (simulating VM1 sending)
+    let frame = Data("test ethernet frame".utf8)
+    let written = frame.withUnsafeBytes { buf in
+        Darwin.write(port1.switchFd, buf.baseAddress!, frame.count)
+    }
+    #expect(written == frame.count)
+
+    // Read from port2's switch-side fd (simulating VM2 receiving)
+    // The relay reads from port1.switchFd and writes to port2.switchFd
+    // For this test, we need to check that the frame was relayed
+    // Use a short timeout to avoid blocking
+    usleep(50_000) // 50ms for relay to process
+
+    var readBuf = [UInt8](repeating: 0, count: 1500)
+    let flags = fcntl(port2.switchFd, F_GETFL)
+    fcntl(port2.switchFd, F_SETFL, flags | O_NONBLOCK)
+    let readCount = Darwin.read(port2.switchFd, &readBuf, readBuf.count)
+
+    #expect(readCount == frame.count)
+    #expect(Data(readBuf[..<readCount]) == frame)
+
+    sw.close()
+}
+
+@Test func networkSwitchIPAssignment() {
+    #expect(NetworkSwitch.ipForIndex(0) == "192.168.100.2")
+    #expect(NetworkSwitch.ipForIndex(1) == "192.168.100.3")
+    #expect(NetworkSwitch.ipForIndex(5) == "192.168.100.7")
+}
+
+@Test func networkSwitchHostsGeneration() {
+    let peers: [(name: String, ip: String)] = [
+        ("db", "192.168.100.2"),
+        ("api", "192.168.100.3"),
+    ]
+    let hosts = NetworkSwitch.generateHosts(peers: peers)
+    #expect(hosts.contains("192.168.100.2 db"))
+    #expect(hosts.contains("192.168.100.3 api"))
+    #expect(hosts.contains("127.0.0.1 localhost"))
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `swift test --filter NetworkSwitchTests 2>&1 | head -20`
+Expected: Compilation errors.
+
+- [ ] **Step 3: Implement NetworkSwitch**
+
+```swift
+// Sources/Lumina/NetworkSwitch.swift
+import Foundation
+
+/// A port on the virtual switch — one end for the VM, one for the relay.
+public struct SwitchPort: Sendable {
+    /// File descriptor given to VZFileHandleNetworkDeviceAttachment (VM side)
+    public let vmFd: Int32
+    /// File descriptor owned by NetworkSwitch (relay side)
+    public let switchFd: Int32
+}
+
+/// Userspace ethernet frame relay using SOCK_DGRAM socketpairs.
+/// VZFileHandleNetworkDeviceAttachment requires datagram sockets because
+/// VZ writes complete Ethernet frames as individual datagrams.
+public final class NetworkSwitch: @unchecked Sendable {
+    private let lock = NSLock()
+    private var ports: [SwitchPort] = []
+    private var relayThread: Thread?
+    private var running = false
+
+    public init() {}
+
+    /// Create a new port on the switch. Returns a pair of fds:
+    /// vmFd goes to VZFileHandleNetworkDeviceAttachment,
+    /// switchFd is used by the relay loop.
+    public func createPort() throws -> SwitchPort {
+        var fds: [Int32] = [0, 0]
+        guard socketpair(AF_UNIX, SOCK_DGRAM, 0, &fds) == 0 else {
+            throw LuminaError.sessionFailed("Failed to create SOCK_DGRAM socketpair: \(errno)")
+        }
+        let port = SwitchPort(vmFd: fds[0], switchFd: fds[1])
+        lock.lock()
+        ports.append(port)
+        lock.unlock()
+        return port
+    }
+
+    /// Start the relay loop on a background thread.
+    /// Reads datagrams from each port's switchFd and writes to all other ports.
+    public func startRelay() {
+        lock.lock()
+        running = true
+        let currentPorts = ports
+        lock.unlock()
+
+        let thread = Thread {
+            self.relayLoop(ports: currentPorts)
+        }
+        thread.qualityOfService = .userInitiated
+        thread.start()
+        relayThread = thread
+    }
+
+    /// Stop the relay and close all fds.
+    public func close() {
+        lock.lock()
+        running = false
+        let currentPorts = ports
+        ports = []
+        lock.unlock()
+
+        for port in currentPorts {
+            Darwin.close(port.vmFd)
+            Darwin.close(port.switchFd)
+        }
+    }
+
+    // MARK: - IP Assignment
+
+    /// Deterministic IP for a session index (0-based).
+    /// Range: 192.168.100.2 through 192.168.100.254
+    public static func ipForIndex(_ index: Int) -> String {
+        "192.168.100.\(index + 2)"
+    }
+
+    /// Generate /etc/hosts content for all peers.
+    public static func generateHosts(peers: [(name: String, ip: String)]) -> String {
+        var lines = ["127.0.0.1 localhost"]
+        for peer in peers {
+            lines.append("\(peer.ip) \(peer.name)")
+        }
+        return lines.joined(separator: "\n") + "\n"
+    }
+
+    // MARK: - Private
+
+    private func relayLoop(ports: [SwitchPort]) {
+        let maxFrame = 1514 // Max ethernet frame size
+        var buffer = [UInt8](repeating: 0, count: maxFrame)
+
+        // Set all switch fds to non-blocking for poll-based relay
+        for port in ports {
+            let flags = fcntl(port.switchFd, F_GETFL)
+            fcntl(port.switchFd, F_SETFL, flags | O_NONBLOCK)
+        }
+
+        while running {
+            var didWork = false
+
+            for (i, srcPort) in ports.enumerated() {
+                let n = Darwin.read(srcPort.switchFd, &buffer, maxFrame)
+                if n > 0 {
+                    didWork = true
+                    // Broadcast to all other ports
+                    for (j, dstPort) in ports.enumerated() where j != i {
+                        _ = buffer.withUnsafeBufferPointer { buf in
+                            Darwin.write(dstPort.switchFd, buf.baseAddress!, n)
+                        }
+                    }
+                }
+            }
+
+            if !didWork {
+                // Sleep briefly to avoid busy-spinning
+                usleep(1000) // 1ms
+            }
+        }
+    }
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `swift test --filter NetworkSwitchTests 2>&1 | tail -5`
+Expected: All 4 tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Sources/Lumina/NetworkSwitch.swift Tests/LuminaTests/NetworkSwitchTests.swift
+git commit -m "feat: add NetworkSwitch with SOCK_DGRAM ethernet frame relay"
+```
+
+---
+
+### Task 9: Network actor, InitrdPatcher, and VM dual-interface
+
+**Files:**
+- Create: `Sources/Lumina/Network.swift`
+- Modify: `Sources/Lumina/Types.swift`
+- Modify: `Sources/Lumina/VM.swift`
+- Modify: `Sources/Lumina/InitrdPatcher.swift`
+- Modify: `Sources/Lumina/Lumina.swift`
+- Test: `Tests/LuminaTests/NetworkTests.swift`
+
+- [ ] **Step 1: Write failing tests**
+
+```swift
+// Tests/LuminaTests/NetworkTests.swift
+import Foundation
+import Testing
+@testable import Lumina
+
+@Test func networkIPAssignment() {
+    #expect(NetworkSwitch.ipForIndex(0) == "192.168.100.2")
+    #expect(NetworkSwitch.ipForIndex(1) == "192.168.100.3")
+}
+
+@Test func networkHostsGeneration() {
+    let peers: [(name: String, ip: String)] = [
+        ("db", "192.168.100.2"),
+        ("api", "192.168.100.3"),
+    ]
+    let hosts = NetworkSwitch.generateHosts(peers: peers)
+    #expect(hosts.contains("192.168.100.2 db"))
+    #expect(hosts.contains("192.168.100.3 api"))
+}
+
+@Test func vmOptionsPrivateNetworkDefault() {
+    let opts = VMOptions()
+    #expect(opts.privateNetworkFd == nil)
+}
+```
+
+- [ ] **Step 2: Add `privateNetworkFd` to VMOptions**
+
+In `Sources/Lumina/Types.swift`, add to `VMOptions`:
+
+```swift
+public var privateNetworkFd: FileHandle?
+```
+
+And to both `init` methods (default `nil`).
+
+- [ ] **Step 3: Add second network interface to VM.boot()**
+
+In `Sources/Lumina/VM.swift`, after the existing network device setup (around line 154), add:
+
+```swift
+// Private network interface (eth1) for VM-to-VM networking
+if let netFd = options.privateNetworkFd {
+    let privateNet = VZVirtioNetworkDeviceConfiguration()
+    privateNet.attachment = VZFileHandleNetworkDeviceAttachment(fileHandle: netFd)
+    config.networkDevices.append(privateNet)
+}
+```
+
+Note: `config.networkDevices` is already set to `[networkDevice]`. Change the initial assignment to `var devices = [networkDevice]`, then conditionally append, then `config.networkDevices = devices`.
+
+- [ ] **Step 4: Add `networkHosts` parameter to InitrdPatcher**
+
+In `Sources/Lumina/InitrdPatcher.swift`, modify `createCombinedInitrd` to accept:
+
+```swift
+static func createCombinedInitrd(
+    baseInitrd: URL,
+    agentBinary: URL,
+    modulesDir: URL?,
+    networkHosts: [String: String]? = nil,
+    outputURL: URL
+) throws(LuminaError) {
+```
+
+After the modules cpio entries, add:
+
+```swift
+// Add /etc/hosts for network peers
+if let hosts = networkHosts {
+    var hostsContent = "127.0.0.1 localhost\n"
+    for (name, ip) in hosts.sorted(by: { $0.key < $1.key }) {
+        hostsContent += "\(ip) \(name)\n"
+    }
+    cpio.append(cpioEntry(path: "lumina-hosts", mode: 0o100644, data: Data(hostsContent.utf8)))
+}
+```
+
+And in the inner init script (`customInitScript` or passed as context), add eth1 configuration:
+
+```shell
+# Configure eth1 for private networking (if lumina_ip is set)
+LUMINA_IP=
+for param in $(cat /proc/cmdline); do
+  case "$param" in
+    lumina_ip=*) LUMINA_IP="${param#lumina_ip=}" ;;
+  esac
+done
+if [ -n "$LUMINA_IP" ]; then
+  ip addr add "$LUMINA_IP/24" dev eth1 2>/dev/null
+  ip link set eth1 up 2>/dev/null
+fi
+
+# Copy network hosts file if present
+if [ -f /lumina-hosts ]; then
+  cp /lumina-hosts /etc/hosts
+fi
+```
+
+- [ ] **Step 5: Create Network actor**
+
+```swift
+// Sources/Lumina/Network.swift
+import Foundation
+
+/// Manages a group of VMs on a shared private network.
+/// All VMs are booted within a single process — no cross-process networking.
+public actor Network {
+    private let name: String
+    private let networkSwitch: NetworkSwitch
+    private var sessions: [(name: String, ip: String, vm: VM)] = []
+
+    public init(name: String) {
+        self.name = name
+        self.networkSwitch = NetworkSwitch()
+    }
+
+    /// Boot a new VM on the network.
+    public func session(
+        name sessionName: String,
+        image: String = "default",
+        options: VMOptions = .default
+    ) async throws -> VM {
+        let index = sessions.count
+        let ip = NetworkSwitch.ipForIndex(index)
+
+        // Create a switch port for this VM
+        let port = try networkSwitch.createPort()
+
+        // Build peer list (including this new session)
+        var allPeers = sessions.map { ($0.name, $0.ip) }
+        allPeers.append((sessionName, ip))
+        let hostsMap = Dictionary(uniqueKeysWithValues: allPeers.map { ($0.0, $0.1) })
+
+        // Configure VM with private network fd
+        var vmOpts = options
+        vmOpts.image = image
+        vmOpts.privateNetworkFd = FileHandle(fileDescriptor: port.vmFd, closeOnDealloc: false)
+        vmOpts.networkHosts = hostsMap
+        vmOpts.networkIP = ip
+
+        let vm = VM(options: vmOpts)
+        try await vm.bootResult().get()
+
+        sessions.append((name: sessionName, ip: ip, vm: vm))
+
+        // Start relay after first two VMs are added
+        if sessions.count == 2 {
+            networkSwitch.startRelay()
+        }
+
+        return vm
+    }
+
+    /// Shutdown all VMs and close the network.
+    public func shutdown() async {
+        for (_, _, vm) in sessions {
+            await vm.shutdown()
+        }
+        networkSwitch.close()
+        sessions = []
+    }
+}
+```
+
+Add to `Sources/Lumina/Lumina.swift`:
+
+```swift
+    /// Run a closure with a private network of VMs.
+    /// All VMs share a virtual switch for VM-to-VM communication.
+    public static func withNetwork<T: Sendable>(
+        _ name: String = "default",
+        body: @Sendable (Network) async throws -> T
+    ) async throws -> T {
+        let network = Network(name: name)
+        do {
+            let result = try await body(network)
+            await network.shutdown()
+            return result
+        } catch {
+            await network.shutdown()
+            throw error
+        }
+    }
+```
+
+Note: `VMOptions` needs `networkHosts: [String: String]?` and `networkIP: String?` fields. Add those to Types.swift.
+
+- [ ] **Step 6: Wire networkHosts/networkIP through VM.boot() to InitrdPatcher**
+
+In `VM.boot()`, pass `options.networkHosts` to `InitrdPatcher.createCombinedInitrd`:
+
+```swift
+try InitrdPatcher.createCombinedInitrd(
+    baseInitrd: imagePaths.initrd,
+    agentBinary: agentURL,
+    modulesDir: imagePaths.modulesDir,
+    networkHosts: options.networkHosts,
+    outputURL: combinedInitrd
+)
+```
+
+And add `lumina_ip` to the kernel cmdline:
+
+```swift
+if let ip = options.networkIP {
+    cmdLine += " lumina_ip=\(ip)"
+}
+```
+
+- [ ] **Step 7: Run tests**
+
+Run: `swift build 2>&1 | tail -10`
+Expected: Build succeeds.
+
+Run: `swift test --filter NetworkTests 2>&1 | tail -5`
+Expected: All tests pass.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add Sources/Lumina/Network.swift Sources/Lumina/NetworkSwitch.swift Sources/Lumina/VM.swift Sources/Lumina/Types.swift Sources/Lumina/InitrdPatcher.swift Sources/Lumina/Lumina.swift Tests/LuminaTests/NetworkTests.swift
+git commit -m "feat: add Network actor with dual-interface VMs and InitrdPatcher hosts injection"
+```
+
+---
+
+### Task 10: Network CLI
+
+**Files:**
+- Modify: `Sources/lumina-cli/main.swift`
+
+- [ ] **Step 1: Add `network run` subcommand**
+
+```swift
+// MARK: - Network
+
+struct NetworkCmd: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "network",
+        abstract: "Run a group of VMs on a shared network",
+        subcommands: [NetworkRun.self]
+    )
+}
+
+struct NetworkRun: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(commandName: "run", abstract: "Run VMs from a manifest file")
+
+    @Option(name: .long, help: "Path to network manifest JSON file")
+    var file: String
+
+    func run() async throws {
+        installSignalHandlers()
+        atexit { DiskClone.cleanOrphans() }
+
+        let fileURL = URL(fileURLWithPath: file)
+        guard FileManager.default.fileExists(atPath: fileURL.path) else {
+            FileHandle.standardError.write(Data("lumina: manifest file not found: \(file)\n".utf8))
+            throw ExitCode.failure
+        }
+
+        let data = try Data(contentsOf: fileURL)
+        let manifest: NetworkManifest
+        do {
+            manifest = try JSONDecoder().decode(NetworkManifest.self, from: data)
+        } catch {
+            FileHandle.standardError.write(Data("lumina: invalid manifest: \(error)\n".utf8))
+            throw ExitCode.failure
+        }
+
+        FileHandle.standardError.write(Data("Starting \(manifest.sessions.count) sessions on shared network...\n".utf8))
+
+        try await Lumina.withNetwork("cli") { network in
+            for session in manifest.sessions {
+                FileHandle.standardError.write(Data("  Booting '\(session.name)' (image: \(session.image ?? "default"))...\n".utf8))
+                _ = try await network.session(
+                    name: session.name,
+                    image: session.image ?? "default"
+                )
+            }
+            FileHandle.standardError.write(Data("All sessions running. Press Ctrl-C to tear down.\n".utf8))
+
+            // Block until signal
+            await withCheckedContinuation { (_: CheckedContinuation<Void, Never>) in
+                // This intentionally never resumes — Ctrl-C triggers signal handler
+                // which cleans up and exits. The `withNetwork` scope ensures shutdown.
+            }
+        }
+    }
+}
+
+struct NetworkManifest: Codable {
+    let sessions: [NetworkSession]
+}
+
+struct NetworkSession: Codable {
+    let name: String
+    let image: String?
+    let volumes: [String]?
+}
+```
+
+Add `NetworkCmd.self` to `LuminaCLI.configuration.subcommands`.
+
+- [ ] **Step 2: Build to verify**
+
+Run: `swift build 2>&1 | tail -10`
+Expected: Build succeeds.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add Sources/lumina-cli/main.swift
+git commit -m "feat: add network run CLI subcommand with manifest support"
+```
+
+---
+
+## Phase 5: Final integration
+
+### Task 11: Full build, test, and CLAUDE.md update
+
+- [ ] **Step 1: Run full build**
+
+Run: `swift build 2>&1 | tail -20`
+Expected: Build succeeds with zero errors.
+
+- [ ] **Step 2: Run all unit tests**
+
+Run: `swift test 2>&1 | tail -30`
+Expected: All tests pass — existing tests still green, new tests green.
+
+- [ ] **Step 3: Update CLAUDE.md with new commands and structure**
+
+Add the new files to the repository structure, new CLI commands, and update dev commands.
+
+- [ ] **Step 4: Update version to 0.3.0**
+
+In `Sources/lumina-cli/main.swift`, update version:
+
+```swift
+version: "0.3.0",
+```
+
+- [ ] **Step 5: Final commit**
+
+```bash
+git add -A
+git commit -m "feat: Lumina v0.3.0 — sessions, custom images, volumes, networking"
+```

--- a/docs/superpowers/plans/2026-04-09-lumina-v1-p0.md
+++ b/docs/superpowers/plans/2026-04-09-lumina-v1-p0.md
@@ -10,6 +10,14 @@
 
 **Spec:** `docs/superpowers/specs/2026-04-09-lumina-v1-p0-design.md`
 
+**Review fixes applied (Carmack + Hickey):**
+1. `VMOptions.privateNetworkFd` is `Int32?` not `FileHandle?` (FileHandle isn't Sendable in Swift 6)
+2. `NetworkSwitch.relayLoop` reads ports under lock each iteration, not a one-time snapshot
+3. `SessionServer` uses `await vm.uploadFilesResult()` / `downloadFilesResult()` patterns for actor safety
+4. `NetworkRun` uses `dispatchMain()` instead of never-resuming continuation
+5. `InitrdPatcher` uses a separate `appendNetworkOverlay()` — existing `createCombinedInitrd` signature unchanged
+6. `VolumeMount` (name + guest path) converts to `MountPoint` (host URL + guest path) at the CLI/session boundary
+
 ---
 
 ## Phase 1: Sessions
@@ -723,21 +731,25 @@ public final class SessionServer: @unchecked Sendable {
     }
 
     private func handleUpload(localPath: String, remotePath: String, vm: VM, handle: FileHandle) async {
-        do {
-            let upload = FileUpload(localPath: URL(fileURLWithPath: localPath), remotePath: remotePath)
-            try vm.uploadFiles([upload])
+        let upload = FileUpload(localPath: URL(fileURLWithPath: localPath), remotePath: remotePath)
+        // Use Result wrapper — uploadFiles is a sync actor method, needs hop via await
+        let result = await vm.uploadFilesResult([upload])
+        switch result {
+        case .success:
             try? writeResponse(.uploadDone(path: remotePath), to: handle)
-        } catch {
+        case .failure(let error):
             try? writeResponse(.error(message: "Upload failed: \(error)"), to: handle)
         }
     }
 
     private func handleDownload(remotePath: String, localPath: String, vm: VM, handle: FileHandle) async {
-        do {
-            let download = FileDownload(remotePath: remotePath, localPath: URL(fileURLWithPath: localPath))
-            try vm.downloadFiles([download])
+        let download = FileDownload(remotePath: remotePath, localPath: URL(fileURLWithPath: localPath))
+        // Use Result wrapper — downloadFiles is a sync actor method, needs hop via await
+        let result = await vm.downloadFilesResult([download])
+        switch result {
+        case .success:
             try? writeResponse(.downloadDone(path: localPath), to: handle)
-        } catch {
+        case .failure(let error):
             try? writeResponse(.error(message: "Download failed: \(error)"), to: handle)
         }
     }
@@ -2255,11 +2267,10 @@ public final class NetworkSwitch: @unchecked Sendable {
     public func startRelay() {
         lock.lock()
         running = true
-        let currentPorts = ports
         lock.unlock()
 
         let thread = Thread {
-            self.relayLoop(ports: currentPorts)
+            self.relayLoop()
         }
         thread.qualityOfService = .userInitiated
         thread.start()
@@ -2299,25 +2310,32 @@ public final class NetworkSwitch: @unchecked Sendable {
 
     // MARK: - Private
 
-    private func relayLoop(ports: [SwitchPort]) {
+    private func relayLoop() {
         let maxFrame = 1514 // Max ethernet frame size
         var buffer = [UInt8](repeating: 0, count: maxFrame)
-
-        // Set all switch fds to non-blocking for poll-based relay
-        for port in ports {
-            let flags = fcntl(port.switchFd, F_GETFL)
-            fcntl(port.switchFd, F_SETFL, flags | O_NONBLOCK)
-        }
+        var knownFds: Set<Int32> = []
 
         while running {
+            // Read ports under lock each iteration — picks up newly added ports
+            lock.lock()
+            let currentPorts = ports
+            lock.unlock()
+
+            // Set any new fds to non-blocking
+            for port in currentPorts where !knownFds.contains(port.switchFd) {
+                let flags = fcntl(port.switchFd, F_GETFL)
+                fcntl(port.switchFd, F_SETFL, flags | O_NONBLOCK)
+                knownFds.insert(port.switchFd)
+            }
+
             var didWork = false
 
-            for (i, srcPort) in ports.enumerated() {
+            for (i, srcPort) in currentPorts.enumerated() {
                 let n = Darwin.read(srcPort.switchFd, &buffer, maxFrame)
                 if n > 0 {
                     didWork = true
                     // Broadcast to all other ports
-                    for (j, dstPort) in ports.enumerated() where j != i {
+                    for (j, dstPort) in currentPorts.enumerated() where j != i {
                         _ = buffer.withUnsafeBufferPointer { buf in
                             Darwin.write(dstPort.switchFd, buf.baseAddress!, n)
                         }
@@ -2326,8 +2344,7 @@ public final class NetworkSwitch: @unchecked Sendable {
             }
 
             if !didWork {
-                // Sleep briefly to avoid busy-spinning
-                usleep(1000) // 1ms
+                usleep(1000) // 1ms — avoid busy-spinning
             }
         }
     }
@@ -2383,7 +2400,7 @@ import Testing
 
 @Test func vmOptionsPrivateNetworkDefault() {
     let opts = VMOptions()
-    #expect(opts.privateNetworkFd == nil)
+    #expect(opts.privateNetworkFd == nil)  // Int32?, not FileHandle — FileHandle isn't Sendable
 }
 ```
 
@@ -2392,10 +2409,12 @@ import Testing
 In `Sources/Lumina/Types.swift`, add to `VMOptions`:
 
 ```swift
-public var privateNetworkFd: FileHandle?
+public var privateNetworkFd: Int32?  // Raw fd, not FileHandle (FileHandle isn't Sendable)
+public var networkHosts: [String: String]?
+public var networkIP: String?
 ```
 
-And to both `init` methods (default `nil`).
+And to both `init` methods (default `nil` for all three).
 
 - [ ] **Step 3: Add second network interface to VM.boot()**
 
@@ -2405,59 +2424,84 @@ In `Sources/Lumina/VM.swift`, after the existing network device setup (around li
 // Private network interface (eth1) for VM-to-VM networking
 if let netFd = options.privateNetworkFd {
     let privateNet = VZVirtioNetworkDeviceConfiguration()
-    privateNet.attachment = VZFileHandleNetworkDeviceAttachment(fileHandle: netFd)
+    // Create FileHandle from raw fd here on the actor's executor (FileHandle isn't Sendable)
+    let netHandle = FileHandle(fileDescriptor: netFd, closeOnDealloc: false)
+    privateNet.attachment = VZFileHandleNetworkDeviceAttachment(fileHandle: netHandle)
     config.networkDevices.append(privateNet)
 }
 ```
 
 Note: `config.networkDevices` is already set to `[networkDevice]`. Change the initial assignment to `var devices = [networkDevice]`, then conditionally append, then `config.networkDevices = devices`.
 
-- [ ] **Step 4: Add `networkHosts` parameter to InitrdPatcher**
+- [ ] **Step 4: Add separate network overlay to InitrdPatcher (composable, no signature change)**
 
-In `Sources/Lumina/InitrdPatcher.swift`, modify `createCombinedInitrd` to accept:
-
-```swift
-static func createCombinedInitrd(
-    baseInitrd: URL,
-    agentBinary: URL,
-    modulesDir: URL?,
-    networkHosts: [String: String]? = nil,
-    outputURL: URL
-) throws(LuminaError) {
-```
-
-After the modules cpio entries, add:
+The existing `createCombinedInitrd` signature is NOT modified. Instead, add a new composable function in `Sources/Lumina/InitrdPatcher.swift`:
 
 ```swift
-// Add /etc/hosts for network peers
-if let hosts = networkHosts {
-    var hostsContent = "127.0.0.1 localhost\n"
-    for (name, ip) in hosts.sorted(by: { $0.key < $1.key }) {
-        hostsContent += "\(ip) \(name)\n"
+    /// Append a network overlay to an existing combined initrd.
+    /// Adds /lumina-hosts file and eth1 configuration to the init script.
+    /// Called AFTER createCombinedInitrd, composes on top of it.
+    static func appendNetworkOverlay(
+        initrdURL: URL,
+        hosts: [String: String],
+        ip: String
+    ) throws(LuminaError) {
+        // Build a supplementary cpio with network files
+        var cpio = Data()
+        cpio.append(cpioEntry(path: ".", mode: 0o40755, data: Data()))
+
+        // /lumina-hosts file
+        var hostsContent = "127.0.0.1 localhost\n"
+        for (name, addr) in hosts.sorted(by: { $0.key < $1.key }) {
+            hostsContent += "\(addr) \(name)\n"
+        }
+        cpio.append(cpioEntry(path: "lumina-hosts", mode: 0o100644, data: Data(hostsContent.utf8)))
+
+        // /lumina-net-init script (sourced by the main init if present)
+        let netInit = """
+        #!/bin/sh
+        # Configure eth1 for private networking
+        ip addr add "\(ip)/24" dev eth1 2>/dev/null
+        ip link set eth1 up 2>/dev/null
+        # Copy network hosts file
+        if [ -f /lumina-hosts ]; then
+            cp /lumina-hosts /etc/hosts
+        fi
+        """
+        cpio.append(cpioEntry(path: "lumina-net-init", mode: 0o100755, data: Data(netInit.utf8)))
+
+        cpio.append(cpioTrailer())
+
+        // Gzip and append to existing initrd
+        let compressedCpio = try gzipCompress(cpio, tempDir: initrdURL.deletingLastPathComponent())
+
+        // Append to existing initrd (Linux supports concatenated initramfs)
+        let handle = try FileHandle(forWritingTo: initrdURL)
+        handle.seekToEndOfFile()
+        handle.write(compressedCpio)
+        try handle.close()
     }
-    cpio.append(cpioEntry(path: "lumina-hosts", mode: 0o100644, data: Data(hostsContent.utf8)))
-}
 ```
 
-And in the inner init script (`customInitScript` or passed as context), add eth1 configuration:
+Then in the inner init script (the `lumina-init` that runs inside the rootfs), add before `exec /usr/local/bin/lumina-agent`:
 
 ```shell
-# Configure eth1 for private networking (if lumina_ip is set)
-LUMINA_IP=
-for param in $(cat /proc/cmdline); do
-  case "$param" in
-    lumina_ip=*) LUMINA_IP="${param#lumina_ip=}" ;;
-  esac
-done
-if [ -n "$LUMINA_IP" ]; then
-  ip addr add "$LUMINA_IP/24" dev eth1 2>/dev/null
-  ip link set eth1 up 2>/dev/null
+# Source network init if present (injected by appendNetworkOverlay)
+if [ -f /lumina-net-init ]; then
+  . /lumina-net-init
 fi
+```
 
-# Copy network hosts file if present
-if [ -f /lumina-hosts ]; then
-  cp /lumina-hosts /etc/hosts
-fi
+This keeps `createCombinedInitrd` unchanged — networking is a composable layer on top. In `VM.boot()`, call it after the existing `createCombinedInitrd`:
+
+```swift
+if let hosts = options.networkHosts, let ip = options.networkIP {
+    try InitrdPatcher.appendNetworkOverlay(
+        initrdURL: combinedInitrd,
+        hosts: hosts,
+        ip: ip
+    )
+}
 ```
 
 - [ ] **Step 5: Create Network actor**
@@ -2495,10 +2539,10 @@ public actor Network {
         allPeers.append((sessionName, ip))
         let hostsMap = Dictionary(uniqueKeysWithValues: allPeers.map { ($0.0, $0.1) })
 
-        // Configure VM with private network fd
+        // Configure VM with private network fd (raw Int32, not FileHandle — Sendable)
         var vmOpts = options
         vmOpts.image = image
-        vmOpts.privateNetworkFd = FileHandle(fileDescriptor: port.vmFd, closeOnDealloc: false)
+        vmOpts.privateNetworkFd = port.vmFd
         vmOpts.networkHosts = hostsMap
         vmOpts.networkIP = ip
 
@@ -2643,11 +2687,9 @@ struct NetworkRun: AsyncParsableCommand {
             }
             FileHandle.standardError.write(Data("All sessions running. Press Ctrl-C to tear down.\n".utf8))
 
-            // Block until signal
-            await withCheckedContinuation { (_: CheckedContinuation<Void, Never>) in
-                // This intentionally never resumes — Ctrl-C triggers signal handler
-                // which cleans up and exits. The `withNetwork` scope ensures shutdown.
-            }
+            // Block main thread until signal — dispatchMain() never returns,
+            // signal handler triggers exit, withNetwork scope ensures shutdown
+            dispatchMain()
         }
     }
 }

--- a/docs/superpowers/specs/2026-04-09-lumina-v1-p0-design.md
+++ b/docs/superpowers/specs/2026-04-09-lumina-v1-p0-design.md
@@ -2,6 +2,7 @@
 
 > Sessions, Custom Images, Persistent Volumes, VM-to-VM Networking.
 > Informed by roundtable debate (Carmack, Hickey, PG) on 2026-04-09.
+> Revised after roundtable spec review — fixes for IPC protocol, DiskClone, volumes, networking.
 
 ---
 
@@ -33,22 +34,34 @@ Per-session background process + Unix domain socket. No daemon. Each session is 
 
 ### IPC protocol (over Unix socket)
 
-NDJSON, same shape as vsock protocol. Agent-consumer-first design.
+NDJSON over Unix domain socket. **This is a separate protocol from the vsock guest protocol** — different senders, different semantics. Defined as `SessionMessage` types in `SessionProtocol.swift`, distinct from `HostMessage`/`GuestMessage` in `Protocol.swift`.
 
+The session server translates between the two: it receives `SessionMessage` from the CLI client, dispatches to the VM actor via the existing `CommandRunner` vsock protocol, and relays results back as `SessionMessage` responses.
+
+**Client → Server messages (`SessionRequest`):**
 ```
-Client → Server: {"type":"exec","cmd":"...","timeout":30,"env":{},"volumes":[{"name":"x","guest_path":"/mnt/x"}]}
-Server → Client: {"type":"output","stream":"stdout","data":"..."}
-Server → Client: {"type":"exit","code":0,"duration_ms":150}
-Client → Server: {"type":"shutdown"}
+{"type":"exec","cmd":"...","timeout":30,"env":{}}
+{"type":"upload","local_path":"/host/file","remote_path":"/guest/file"}
+{"type":"download","remote_path":"/guest/file","local_path":"/host/file"}
+{"type":"shutdown"}
 ```
 
-Additional messages for file operations:
+**Server → Client messages (`SessionResponse`):**
 ```
-Client → Server: {"type":"upload","path":"/guest/path","data":"<base64>","seq":0}
-Server → Client: {"type":"upload_ack","seq":0}
-Client → Server: {"type":"download_req","path":"/guest/path"}
-Server → Client: {"type":"download_data","path":"/guest/path","data":"<base64>"}
+{"type":"output","stream":"stdout","data":"..."}
+{"type":"exit","code":0,"duration_ms":150}
+{"type":"error","message":"session_dead"}
+{"type":"upload_done","path":"/guest/file"}
+{"type":"download_done","path":"/host/file"}
 ```
+
+### Session crash recovery
+
+**VM crash during exec:** The session server detects EOF on the vsock connection (CommandRunner returns `.connectionFailed`). It returns `{"type":"error","message":"vm_crashed","serial_log_tail":"..."}` to the client. The session enters a terminal `dead` state — no restart, no implicit recovery. The client must start a new session.
+
+**Session process crash (SIGKILL/OOM):** The Unix socket disappears. Next `lumina exec` or `lumina session list` detects stale PID via `kill(pid, 0)`, cleans up the session directory and COW clone, returns `{"error":"session_dead","sid":"..."}`.
+
+**SIGTERM/SIGINT on session process:** Graceful VM shutdown + COW clone removal (reuses existing signal handling).
 
 ### CLI interface
 
@@ -64,19 +77,15 @@ lumina session list                    # JSON array of session metadata
 lumina session list --text             # human-readable table
 ```
 
-### Failure recovery
-
-- **Stale session detection:** On connect, if socket fails, check PID via `kill(pid, 0)`. If dead: remove session directory, clean COW clone via existing `DiskClone` orphan logic, return `{"error":"session_dead","sid":"..."}`.
-- **`lumina session list`:** Marks dead sessions with `"status":"dead"`. `lumina clean` garbage-collects them.
-- **SIGTERM/SIGINT on session process:** Graceful VM shutdown + COW clone removal (reuses existing signal handling).
-- **Hard crash (SIGKILL/OOM):** Next `exec` or `list` detects stale PID, triggers cleanup.
+**Note:** `--volume` is only valid on `session start`, not on `exec`. VirtioFS shares are boot-time configuration — they cannot be added to a running VM. Volumes must be declared when the session is created.
 
 ### What changes in existing code
 
 | File | Change |
 |------|--------|
-| `Sources/Lumina/SessionServer.swift` | **New.** Unix socket listener, accepts IPC connections, dispatches to VM actor |
-| `Sources/Lumina/SessionClient.swift` | **New.** Connects to session socket, sends commands, receives output stream |
+| `Sources/Lumina/SessionProtocol.swift` | **New.** `SessionRequest`/`SessionResponse` enums + NDJSON encode/decode (separate from vsock `Protocol.swift`) |
+| `Sources/Lumina/SessionServer.swift` | **New.** Unix socket listener, accepts IPC connections, translates SessionMessages to CommandRunner calls |
+| `Sources/Lumina/SessionClient.swift` | **New.** Connects to session socket, sends SessionRequest, receives SessionResponse stream |
 | `Sources/Lumina/Session.swift` | **New.** Session metadata, filesystem paths, PID management |
 | `Sources/Lumina/Lumina.swift` | Add `Lumina.session(start:)`, `Lumina.exec(sid:)`, `Lumina.sessionStop(sid:)` |
 | `Sources/Lumina/Types.swift` | Add `SessionOptions`, `SessionInfo`, `SessionState` types |
@@ -96,17 +105,23 @@ lumina session list --text             # human-readable table
 
 ### Mechanism
 
-Boot a VM from base image, run setup command, save modified rootfs as new named image. The DiskClone COW copy is promoted to ImageStore instead of deleted.
+Boot a VM from base image, run setup command, save modified rootfs as new named image. `ImageStore.create()` handles the entire image creation lifecycle — DiskClone stays purely ephemeral.
 
 ### Image creation flow
 
 1. Resolve base image via `ImageStore.resolve(name:)`
 2. Create COW clone via `DiskClone.create()`
 3. Boot VM, exec the setup command, wait for exit code 0
-4. On success: copy COW clone's `rootfs.img` to `~/.lumina/images/<new_name>/`
-5. Symlink shared assets from base: `vmlinuz`, `initrd`, `modules/`, `lumina-agent`
-6. Write `meta.json` with lineage info
-7. On failure: delete COW clone, report error
+4. On success: `ImageStore.create(name:from:rootfsSource:command:)` does:
+   a. Create staging dir at `~/.lumina/images/.tmp-<uuid>/`
+   b. Copy COW clone's `rootfs.img` (via `DiskClone.rootfs` public property) into staging dir
+   c. Create symlinks to base image's `vmlinuz`, `initrd`, `modules/`, `lumina-agent`
+   d. Write `meta.json` with lineage info
+   e. Atomic `rename()` staging dir to `~/.lumina/images/<new_name>/`
+5. DiskClone gets normal `remove()` — it stays ephemeral, no `promote()` method
+6. On failure: delete COW clone, clean up staging dir if it exists, report error
+
+**Atomicity:** The staging-dir + `rename()` pattern ensures no partial images. If the process crashes mid-creation, the `.tmp-*` dir is cleaned up on next `ImageStore` operation (same pattern as `DiskClone.cleanOrphans()`).
 
 ### Filesystem layout
 
@@ -134,8 +149,7 @@ lumina image inspect python               # full metadata
 
 | File | Change |
 |------|--------|
-| `Sources/Lumina/ImageStore.swift` | Add `create(name:from:command:)`, `remove(name:)`, `inspect(name:)`, dependency checking |
-| `Sources/Lumina/DiskClone.swift` | Add `promote(to:)` — moves COW clone rootfs to target path instead of deleting |
+| `Sources/Lumina/ImageStore.swift` | Add `create(name:from:rootfsSource:command:)` with staging-dir atomicity, `remove(name:)` with dependency checking, `inspect(name:)` |
 | `Sources/Lumina/Lumina.swift` | Add `Lumina.createImage(name:from:command:)` convenience |
 | `Sources/Lumina/Types.swift` | Add `ImageInfo` type (name, base, size, created, command) |
 | `Sources/lumina-cli/main.swift` | Add `image create`, `image remove`, `image inspect` subcommands |
@@ -174,9 +188,9 @@ lumina volume inspect pycache                         # size, last_used, created
 # Use with one-shot runs
 lumina run --volume pycache:/root/.cache/pip "pip install pandas"
 
-# Use with sessions
-lumina session start --volume cache:/root/.cache
-lumina exec $sid --volume data:/mnt/data "python3 train.py"
+# Use with sessions (volumes declared at session start, not exec — VirtioFS is boot-time only)
+lumina session start --volume cache:/root/.cache --volume data:/mnt/data
+lumina exec $sid "python3 train.py"
 ```
 
 ### Concurrency semantics
@@ -208,17 +222,41 @@ Multiple VMs can mount the same volume simultaneously. VirtioFS is a passthrough
 
 ### Mechanism
 
-`VZFileHandleNetworkDeviceAttachment` provides file descriptors for raw ethernet frame I/O. A userspace `NetworkSwitch` relays frames between connected VMs via socketpairs.
+`VZFileHandleNetworkDeviceAttachment` provides file descriptors for raw ethernet frame I/O. VZ emulates an Ethernet device — frames, not streams — so the file descriptors **must be datagram sockets**. Each VM-to-switch connection uses:
 
-Each networked VM gets two interfaces:
+```swift
+var fds: [Int32] = [0, 0]
+socketpair(AF_UNIX, SOCK_DGRAM, 0, &fds)
+// fds[0] → given to VZFileHandleNetworkDeviceAttachment (VM side)
+// fds[1] → owned by NetworkSwitch (relay side)
+```
+
+**Critical:** `SOCK_DGRAM` is required, not `SOCK_STREAM`. VZ writes complete Ethernet frames as individual datagrams. Stream sockets lose frame boundaries and silently corrupt the network — the VM's network stack hangs with no useful error.
+
+A userspace `NetworkSwitch` reads datagrams from each VM's relay fd and writes them to all other VMs' relay fds (simple hub/broadcast model). Each networked VM gets two interfaces:
 - `eth0` — NAT (existing `VZNATNetworkDeviceAttachment`) for internet access
 - `eth1` — Private network via `VZFileHandleNetworkDeviceAttachment` for VM-to-VM
+
+### VMOptions wiring
+
+`VMOptions` gains an optional `privateNetworkFd: FileHandle?` field. When set, `VM.boot()` creates a second `VZVirtioNetworkDeviceConfiguration` with `VZFileHandleNetworkDeviceAttachment(fileHandle: privateNetworkFd)` and appends it to `config.networkDevices`. The existing NAT device remains at index 0 (eth0); the private network becomes index 1 (eth1).
 
 ### IP assignment and DNS
 
 - IPs assigned deterministically from `192.168.100.0/24` by session index (`.2`, `.3`, `.4`, ...)
-- DNS via `/etc/hosts` injection: `InitrdPatcher` writes host entries for all peers before boot
-- No dnsmasq, no dynamic DNS. Static hosts file is sufficient for group-based networks.
+- DNS via `/etc/hosts` injection into the initrd overlay
+
+### InitrdPatcher changes
+
+`InitrdPatcher.createCombinedInitrd` gains a new parameter: `networkHosts: [String: String]?` — a hostname-to-IP mapping (e.g., `["db": "192.168.100.2", "api": "192.168.100.3"]`). When non-nil:
+
+1. A `/lumina-hosts` file is added as a cpio entry containing the hosts file content
+2. The `customInitScript()` inner init (`/sysroot/sbin/lumina-init`) gains lines to:
+   - Copy `/lumina-hosts` to `/sysroot/etc/hosts` (alongside the rootfs mount)
+   - Configure `eth1` with the assigned static IP via `ip addr add <ip>/24 dev eth1 && ip link set eth1 up`
+3. The assigned IP is passed via kernel cmdline: `lumina_ip=192.168.100.2`
+
+This is a non-trivial addition to `InitrdPatcher` — estimated ~40 lines of init script changes and ~15 lines of cpio generation.
 
 ### Library API
 
@@ -252,12 +290,12 @@ lumina network run --file stack.json
 
 | File | Change |
 |------|--------|
-| `Sources/Lumina/NetworkSwitch.swift` | **New.** ~200 lines. Userspace ethernet frame relay between file handle pairs |
+| `Sources/Lumina/NetworkSwitch.swift` | **New.** ~200 lines. Userspace SOCK_DGRAM relay between VM file handle pairs (hub model) |
 | `Sources/Lumina/Network.swift` | **New.** Network actor: manages switch + session registry + IP assignment + hosts generation |
 | `Sources/Lumina/Lumina.swift` | Add `Lumina.withNetwork()` convenience |
-| `Sources/Lumina/VM.swift` | Support optional second network interface via `VZFileHandleNetworkDeviceAttachment` |
-| `Sources/Lumina/InitrdPatcher.swift` | Inject `/etc/hosts` entries for network peers |
-| `Guest/lumina-agent/main.go` | Configure `eth1` with static IP if network config present (or handle in init script) |
+| `Sources/Lumina/VM.swift` | Support optional `privateNetworkFd` — creates second `VZVirtioNetworkDeviceConfiguration` with `VZFileHandleNetworkDeviceAttachment` |
+| `Sources/Lumina/Types.swift` | Add `privateNetworkFd: FileHandle?` to `VMOptions` |
+| `Sources/Lumina/InitrdPatcher.swift` | Add `networkHosts: [String: String]?` param to `createCombinedInitrd`. New cpio entry for `/lumina-hosts`. Init script changes: copy hosts file, configure eth1 with static IP from `lumina_ip` cmdline param (~55 new lines) |
 | `Sources/lumina-cli/main.swift` | Add `network run` subcommand |
 
 ### What's explicitly deferred
@@ -282,11 +320,12 @@ lumina network run --file stack.json
 
 | Module | Lines (est.) | Purpose |
 |--------|-------------|---------|
-| `SessionServer.swift` | ~250 | Unix socket listener + IPC dispatch |
-| `SessionClient.swift` | ~150 | Connect to session, send/receive |
+| `SessionProtocol.swift` | ~120 | `SessionRequest`/`SessionResponse` enums + NDJSON codec |
+| `SessionServer.swift` | ~250 | Unix socket listener, translates SessionMessages → CommandRunner |
+| `SessionClient.swift` | ~150 | Connect to session, send SessionRequest, receive SessionResponse |
 | `Session.swift` | ~100 | Metadata, paths, PID management |
 | `VolumeStore.swift` | ~100 | Named volume CRUD |
-| `NetworkSwitch.swift` | ~200 | Userspace ethernet relay |
+| `NetworkSwitch.swift` | ~200 | Userspace SOCK_DGRAM ethernet relay |
 | `Network.swift` | ~200 | Network actor, IP assignment, hosts |
 
 ### Types additions (Types.swift)
@@ -325,8 +364,14 @@ public struct NetworkConfig: Sendable { ... }
      │                  │                  │               │
      │                  │                  │               └─ NetworkSwitch + Network actor + dual-interface VM
      │                  │                  └─ VolumeStore + --volume flag + VirtioFS wiring
-     │                  └─ ImageStore.create + DiskClone.promote + image CLI
+     │                  └─ ImageStore.create (staging dir atomicity) + image CLI
      └─ SessionServer + SessionClient + session CLI + exec subcommand
 ```
 
 Each step builds on the last. Sessions are the foundation — custom images, volumes, and networking all integrate with sessions.
+
+### Concurrency notes
+
+**ImageStore concurrent access:** Two concurrent `image create` calls could race on the same image name. The staging-dir + atomic `rename()` pattern handles this — last writer wins, no partial images. Two concurrent `Lumina.run()` calls resolving the same image for read is safe (APFS COW clone from a read-only source).
+
+**Guest agent lifespan:** The existing guest agent (`Guest/lumina-agent/main.go`) already supports multiple exec requests per connection via its `for scanner.Scan()` command loop. No guest agent changes are needed for sessions — the agent stays connected and accepts sequential exec messages. The heartbeat mechanism (5s keepalive when idle) keeps the vsock connection alive between execs.

--- a/docs/superpowers/specs/2026-04-09-lumina-v1-p0-design.md
+++ b/docs/superpowers/specs/2026-04-09-lumina-v1-p0-design.md
@@ -1,0 +1,332 @@
+# Lumina v1 P0 Design Spec
+
+> Sessions, Custom Images, Persistent Volumes, VM-to-VM Networking.
+> Informed by roundtable debate (Carmack, Hickey, PG) on 2026-04-09.
+
+---
+
+## 1. Sessions (CLI-exposed lifecycle API)
+
+### Architecture
+
+Per-session background process + Unix domain socket. No daemon. Each session is an independent process managing one VM actor.
+
+**Decision rationale:** Roundtable unanimous — per-session processes preserve the "no shared mutable state" invariant, contain blast radius (session crash doesn't affect others), and the process table serves as the session registry. The repo's split trigger ("persistent coordinator managing multiple VM actors") is deliberately not crossed.
+
+### Session lifecycle
+
+1. `lumina session start` spawns a background process (`lumina-session` subcommand)
+2. Background process boots VM via existing `VM.boot()`, listens on Unix socket
+3. CLI client prints session ID to stdout (JSON: `{"sid":"<uuid>"}`)
+4. `lumina exec <sid> "cmd"` connects to socket, sends exec, receives streaming output
+5. `lumina session stop <sid>` sends shutdown message, process exits, cleanup runs
+6. `lumina session list` scans `~/.lumina/sessions/`, checks PID liveness
+
+### Filesystem layout
+
+```
+~/.lumina/sessions/<sid>/
+├── control.sock     # Unix domain socket for IPC
+├── meta.json        # {"pid":1234,"image":"default","cpus":2,"memory":"512MB","created":"..."}
+└── run/             # DiskClone COW clone directory (same as one-shot runs)
+```
+
+### IPC protocol (over Unix socket)
+
+NDJSON, same shape as vsock protocol. Agent-consumer-first design.
+
+```
+Client → Server: {"type":"exec","cmd":"...","timeout":30,"env":{},"volumes":[{"name":"x","guest_path":"/mnt/x"}]}
+Server → Client: {"type":"output","stream":"stdout","data":"..."}
+Server → Client: {"type":"exit","code":0,"duration_ms":150}
+Client → Server: {"type":"shutdown"}
+```
+
+Additional messages for file operations:
+```
+Client → Server: {"type":"upload","path":"/guest/path","data":"<base64>","seq":0}
+Server → Client: {"type":"upload_ack","seq":0}
+Client → Server: {"type":"download_req","path":"/guest/path"}
+Server → Client: {"type":"download_data","path":"/guest/path","data":"<base64>"}
+```
+
+### CLI interface
+
+```bash
+sid=$(lumina session start)
+sid=$(lumina session start --image python --cpus 4 --memory 1GB --volume cache:/root/.cache)
+lumina exec $sid "pip install pandas"
+lumina exec $sid --stream "make test"
+lumina exec $sid --copy local.txt:/tmp/local.txt "cat /tmp/local.txt"
+lumina exec $sid --download /tmp/result.txt:./result.txt "generate-report"
+lumina session stop $sid
+lumina session list                    # JSON array of session metadata
+lumina session list --text             # human-readable table
+```
+
+### Failure recovery
+
+- **Stale session detection:** On connect, if socket fails, check PID via `kill(pid, 0)`. If dead: remove session directory, clean COW clone via existing `DiskClone` orphan logic, return `{"error":"session_dead","sid":"..."}`.
+- **`lumina session list`:** Marks dead sessions with `"status":"dead"`. `lumina clean` garbage-collects them.
+- **SIGTERM/SIGINT on session process:** Graceful VM shutdown + COW clone removal (reuses existing signal handling).
+- **Hard crash (SIGKILL/OOM):** Next `exec` or `list` detects stale PID, triggers cleanup.
+
+### What changes in existing code
+
+| File | Change |
+|------|--------|
+| `Sources/Lumina/SessionServer.swift` | **New.** Unix socket listener, accepts IPC connections, dispatches to VM actor |
+| `Sources/Lumina/SessionClient.swift` | **New.** Connects to session socket, sends commands, receives output stream |
+| `Sources/Lumina/Session.swift` | **New.** Session metadata, filesystem paths, PID management |
+| `Sources/Lumina/Lumina.swift` | Add `Lumina.session(start:)`, `Lumina.exec(sid:)`, `Lumina.sessionStop(sid:)` |
+| `Sources/Lumina/Types.swift` | Add `SessionOptions`, `SessionInfo`, `SessionState` types |
+| `Sources/lumina-cli/main.swift` | Add `session start/stop/list` and `exec` subcommands |
+| `Sources/lumina-cli/SessionDaemon.swift` | **New.** Entry point for background session process (`lumina-session` hidden subcommand) |
+
+### Invariants
+
+- Each session process manages exactly one VM actor. No multi-VM processes (except networking, see Section 4).
+- No "session manager" object that coordinates across sessions. Filesystem is the registry.
+- Session process must be fully functional without any other session process running.
+- All session types must be `Sendable`.
+
+---
+
+## 2. Custom Images
+
+### Mechanism
+
+Boot a VM from base image, run setup command, save modified rootfs as new named image. The DiskClone COW copy is promoted to ImageStore instead of deleted.
+
+### Image creation flow
+
+1. Resolve base image via `ImageStore.resolve(name:)`
+2. Create COW clone via `DiskClone.create()`
+3. Boot VM, exec the setup command, wait for exit code 0
+4. On success: copy COW clone's `rootfs.img` to `~/.lumina/images/<new_name>/`
+5. Symlink shared assets from base: `vmlinuz`, `initrd`, `modules/`, `lumina-agent`
+6. Write `meta.json` with lineage info
+7. On failure: delete COW clone, report error
+
+### Filesystem layout
+
+```
+~/.lumina/images/python/
+├── rootfs.img           # Modified rootfs (full copy, not COW — survives base deletion)
+├── vmlinuz -> ../default/vmlinuz
+├── initrd -> ../default/initrd
+├── modules -> ../default/modules
+├── lumina-agent -> ../default/lumina-agent
+└── meta.json            # {"base":"default","command":"apk add python3 py3-pip","created":"..."}
+```
+
+### CLI interface
+
+```bash
+lumina image create python --from default --run "apk add python3 py3-pip"
+lumina image create ml --from python --run "pip install numpy pandas scikit-learn"
+lumina image list                         # name, base, size, created
+lumina image remove python                # refuses if dependents exist
+lumina image inspect python               # full metadata
+```
+
+### What changes in existing code
+
+| File | Change |
+|------|--------|
+| `Sources/Lumina/ImageStore.swift` | Add `create(name:from:command:)`, `remove(name:)`, `inspect(name:)`, dependency checking |
+| `Sources/Lumina/DiskClone.swift` | Add `promote(to:)` — moves COW clone rootfs to target path instead of deleting |
+| `Sources/Lumina/Lumina.swift` | Add `Lumina.createImage(name:from:command:)` convenience |
+| `Sources/Lumina/Types.swift` | Add `ImageInfo` type (name, base, size, created, command) |
+| `Sources/lumina-cli/main.swift` | Add `image create`, `image remove`, `image inspect` subcommands |
+
+### Invariants
+
+- Image creation is atomic: either the full image directory exists with all files, or it doesn't. No partial images.
+- `image remove` refuses if other images list this as their base (check all `meta.json` files).
+- The `default` image (pulled from GitHub Releases) cannot be removed.
+- Image creation reuses the same VM boot path as `Lumina.run()` — no special image-building VM.
+
+---
+
+## 3. Persistent Volumes
+
+### Model
+
+Named host directories under `~/.lumina/volumes/<name>/`, mounted into VMs via existing VirtioFS plumbing. Volumes have their own lifecycle, independent of VMs and sessions.
+
+### Filesystem layout
+
+```
+~/.lumina/volumes/<name>/
+├── data/                # The actual shared directory (VirtioFS mount target)
+└── meta.json            # {"created":"...","last_used":"..."}
+```
+
+### CLI interface
+
+```bash
+lumina volume create pycache
+lumina volume list                                    # name, size, last_used
+lumina volume remove pycache
+lumina volume inspect pycache                         # size, last_used, created
+
+# Use with one-shot runs
+lumina run --volume pycache:/root/.cache/pip "pip install pandas"
+
+# Use with sessions
+lumina session start --volume cache:/root/.cache
+lumina exec $sid --volume data:/mnt/data "python3 train.py"
+```
+
+### Concurrency semantics
+
+Multiple VMs can mount the same volume simultaneously. VirtioFS is a passthrough — host filesystem semantics apply. No locking. Concurrent writes to the same file are undefined behavior (same as Docker volumes).
+
+### What changes in existing code
+
+| File | Change |
+|------|--------|
+| `Sources/Lumina/VolumeStore.swift` | **New.** ~100 lines. `create(name:)`, `remove(name:)`, `resolve(name:) -> URL`, `list()`, `inspect(name:)` |
+| `Sources/Lumina/Types.swift` | Add `VolumeMount` type (name + guest path), add `volumes` field to `RunOptions` and `VMOptions` |
+| `Sources/Lumina/VM.swift` | Resolve volume names to host paths, add as VirtioFS shares in `VZVirtualMachineConfiguration` |
+| `Sources/lumina-cli/main.swift` | Add `volume create/list/remove/inspect` subcommands, `--volume name:path` flag |
+
+### Invariants
+
+- Volumes are just managed directories. No disk images, no quotas (deferred to P2).
+- `volume remove` deletes the directory. No refcounting — if a VM has it mounted, the mount becomes empty.
+- `last_used` updated on every VM boot that references the volume.
+
+---
+
+## 4. VM-to-VM Networking
+
+### Scope
+
+**Group-based networking only.** VMs launched together in a single process share a virtual switch. Cross-session networking (VMs from separate CLI invocations finding each other) is deferred — it requires cross-process coordination that approaches daemon territory.
+
+### Mechanism
+
+`VZFileHandleNetworkDeviceAttachment` provides file descriptors for raw ethernet frame I/O. A userspace `NetworkSwitch` relays frames between connected VMs via socketpairs.
+
+Each networked VM gets two interfaces:
+- `eth0` — NAT (existing `VZNATNetworkDeviceAttachment`) for internet access
+- `eth1` — Private network via `VZFileHandleNetworkDeviceAttachment` for VM-to-VM
+
+### IP assignment and DNS
+
+- IPs assigned deterministically from `192.168.100.0/24` by session index (`.2`, `.3`, `.4`, ...)
+- DNS via `/etc/hosts` injection: `InitrdPatcher` writes host entries for all peers before boot
+- No dnsmasq, no dynamic DNS. Static hosts file is sufficient for group-based networks.
+
+### Library API
+
+```swift
+try await Lumina.withNetwork("mynet") { network in
+    let db = try await network.session(name: "db", image: "postgres")
+    let api = try await network.session(name: "api", image: "node")
+    let result = try await api.exec("curl http://db:5432")
+}
+// All VMs shut down, network torn down
+```
+
+### CLI interface
+
+```bash
+# From manifest file
+lumina network run --file stack.json
+
+# stack.json:
+# {
+#   "sessions": [
+#     {"name": "db", "image": "postgres"},
+#     {"name": "api", "image": "node", "volumes": ["code:/app"]}
+#   ]
+# }
+
+# All sessions share a private network. Ctrl-C tears down everything.
+```
+
+### What changes in existing code
+
+| File | Change |
+|------|--------|
+| `Sources/Lumina/NetworkSwitch.swift` | **New.** ~200 lines. Userspace ethernet frame relay between file handle pairs |
+| `Sources/Lumina/Network.swift` | **New.** Network actor: manages switch + session registry + IP assignment + hosts generation |
+| `Sources/Lumina/Lumina.swift` | Add `Lumina.withNetwork()` convenience |
+| `Sources/Lumina/VM.swift` | Support optional second network interface via `VZFileHandleNetworkDeviceAttachment` |
+| `Sources/Lumina/InitrdPatcher.swift` | Inject `/etc/hosts` entries for network peers |
+| `Guest/lumina-agent/main.go` | Configure `eth1` with static IP if network config present (or handle in init script) |
+| `Sources/lumina-cli/main.swift` | Add `network run` subcommand |
+
+### What's explicitly deferred
+
+- `lumina network create/remove` as standalone lifecycle commands (needs daemon)
+- Cross-session networking (needs shared state across processes)
+- Dynamic DNS / adding VMs to a running network
+- Network policies / firewalling between VMs
+
+### Invariants
+
+- A `NetworkSwitch` lives within a single process. No cross-process frame relay.
+- All VMs on a network are booted and managed by the same `Network` actor.
+- Internet access (NAT on eth0) always works alongside private networking (eth1).
+- Network teardown is automatic when the `withNetwork` scope exits.
+
+---
+
+## Cross-cutting concerns
+
+### New module inventory
+
+| Module | Lines (est.) | Purpose |
+|--------|-------------|---------|
+| `SessionServer.swift` | ~250 | Unix socket listener + IPC dispatch |
+| `SessionClient.swift` | ~150 | Connect to session, send/receive |
+| `Session.swift` | ~100 | Metadata, paths, PID management |
+| `VolumeStore.swift` | ~100 | Named volume CRUD |
+| `NetworkSwitch.swift` | ~200 | Userspace ethernet relay |
+| `Network.swift` | ~200 | Network actor, IP assignment, hosts |
+
+### Types additions (Types.swift)
+
+```swift
+public struct SessionOptions: Sendable { ... }
+public struct SessionInfo: Sendable { ... }
+public enum SessionState: String, Sendable { case running, dead }
+public struct ImageInfo: Sendable { ... }
+public struct VolumeMount: Sendable { ... }
+public struct NetworkConfig: Sendable { ... }
+```
+
+### Testing strategy
+
+**Unit tests (no VM required):**
+- Session IPC protocol encode/decode
+- Session metadata serialization
+- ImageStore create/remove/dependency checking (mock filesystem)
+- VolumeStore CRUD
+- NetworkSwitch frame relay (mock file handles)
+- IP assignment determinism
+- Hosts file generation
+
+**Integration tests (require VM):**
+- Session start → exec → stop lifecycle
+- Session crash recovery (kill session process, verify cleanup)
+- Image create from base → use in session
+- Volume mount → write file → remount in new session → read file
+- Two VMs on network → ping/curl between them
+
+### Implementation order
+
+```
+1. Sessions ──→ 2. Custom Images ──→ 3. Volumes ──→ 4. Networking
+     │                  │                  │               │
+     │                  │                  │               └─ NetworkSwitch + Network actor + dual-interface VM
+     │                  │                  └─ VolumeStore + --volume flag + VirtioFS wiring
+     │                  └─ ImageStore.create + DiskClone.promote + image CLI
+     └─ SessionServer + SessionClient + session CLI + exec subcommand
+```
+
+Each step builds on the last. Sessions are the foundation — custom images, volumes, and networking all integrate with sessions.


### PR DESCRIPTION
## Summary

Implements the v1 P0 design spec — 11 tasks across 5 phases, adding four major features to Lumina:

- **Sessions** — persistent VMs with Unix socket IPC (`session start/stop/list`, `exec`)
- **Custom Images** — create images by running commands in VMs, staging-dir atomicity (`images create/remove/inspect`)
- **Volumes** — named persistent host directories mounted via VirtioFS (`volume create/list/remove/inspect`, `--volume` on `run`)
- **VM-to-VM Networking** — SOCK_DGRAM ethernet relay, Network actor, dual-NIC VMs (`network run --file manifest.json`)

### Key numbers
- 87 unit tests, 6 e2e integration tests — all passing
- ~2s cold boot, ~0ms session exec latency
- 5MB file transfer with verified integrity (MD5 match)
- 20 rapid-fire execs on a single session — all succeed
- Full filesystem isolation between concurrent sessions

### Files changed
- **11 new source files** in `Sources/Lumina/` (Session, SessionProtocol, SessionServer, SessionClient, SessionProcess, Network, NetworkSwitch, VolumeStore + types)
- **3 CLI files** in `Sources/lumina-cli/` (CLI.swift refactored from main.swift, Helpers.swift, SessionProcess.swift)
- **8 new test files** covering all new subsystems
- CLAUDE.md updated with new architecture, commands, Makefile-based dev workflow
- Version bumped to 0.3.0

### Architecture decisions (Carmack + Hickey review applied)
1. `VMOptions.privateNetworkFd` is `Int32?` not `FileHandle?` (FileHandle isn't Sendable)
2. `NetworkSwitch.relayLoop` reads ports under lock each iteration (dynamic VM join)
3. `SessionServer` uses `await vm.uploadFilesResult()` patterns for actor safety
4. `NetworkRun` uses `dispatchMain()` instead of never-resuming continuation
5. `InitrdPatcher.appendNetworkOverlay()` is composable — existing signature unchanged
6. `VolumeMount` (name + guest path) converts to `MountPoint` (host URL + guest path) at CLI boundary

## Test plan

- [x] `make build` — clean build + codesign
- [x] `make test` — 87/87 unit tests pass
- [x] `make test-integration` — 6/6 e2e tests pass
- [x] Session lifecycle: start → exec (20 rapid) → stop → verify cleanup
- [x] Volume persistence: write in session → read from new disposable VM
- [x] Image inspect/list/remove with dependency checks
- [x] File upload/download with MD5 integrity verification
- [x] Concurrent sessions with filesystem isolation
- [x] Edge cases: empty command, timeout, unicode, 1.4MB stdout, binary data
- [x] Network: DNS resolution, HTTP fetch, file download from internet
- [x] Real workflows: Python dev loop, Go compile+run, Node.js CI pipeline
