### PR TITLE
fix: resolve 15 agent stress-test issues

### DIFF
--- a/Guest/lumina-agent/main.go
+++ b/Guest/lumina-agent/main.go
@@ -313,29 +313,52 @@ func handleUpload(conn net.Conn, scanner *bufio.Scanner, first UploadMsg) {
 }
 
 func handleDownload(conn net.Conn, req DownloadReqMsg) {
-	data, err := os.ReadFile(req.Path)
+	f, err := os.Open(req.Path)
 	if err != nil {
 		sendJSON(conn, map[string]interface{}{
 			"type": "download_error", "path": req.Path, "error": err.Error(),
 		})
 		return
 	}
+	defer f.Close()
 
-	// Send in 48KB raw chunks (~64KB base64)
+	// Stream in 48KB raw chunks (~64KB base64) — never load entire file into memory.
+	// Go's Read can return (n>0, io.EOF) on the last read, or (n>0, nil) followed
+	// by (0, io.EOF). Handle both: set eof when readErr==io.EOF, and if we reach
+	// a zero-byte EOF without having sent eof yet, send a final empty chunk.
 	const chunkSize = 48 * 1024
+	buf := make([]byte, chunkSize)
 	seq := 0
-	for offset := 0; offset < len(data) || seq == 0; offset += chunkSize {
-		end := offset + chunkSize
-		if end > len(data) {
-			end = len(data)
+	sentEof := false
+	for {
+		n, readErr := f.Read(buf)
+		if n > 0 {
+			b64 := base64.StdEncoding.EncodeToString(buf[:n])
+			eof := readErr == io.EOF
+			sendJSON(conn, map[string]interface{}{
+				"type": "download_data", "path": req.Path, "data": b64, "seq": seq, "eof": eof,
+			})
+			seq++
+			if eof {
+				sentEof = true
+			}
 		}
-		chunk := data[offset:end]
-		b64 := base64.StdEncoding.EncodeToString(chunk)
-		eof := end >= len(data)
-		sendJSON(conn, map[string]interface{}{
-			"type": "download_data", "path": req.Path, "data": b64, "seq": seq, "eof": eof,
-		})
-		seq++
+		if readErr != nil {
+			if readErr == io.EOF {
+				if !sentEof {
+					// Either empty file or exact multiple of chunkSize —
+					// send final chunk so the host sees eof: true
+					sendJSON(conn, map[string]interface{}{
+						"type": "download_data", "path": req.Path, "data": "", "seq": seq, "eof": true,
+					})
+				}
+				return
+			}
+			sendJSON(conn, map[string]interface{}{
+				"type": "download_error", "path": req.Path, "error": readErr.Error(),
+			})
+			return
+		}
 	}
 }
 

--- a/Sources/Lumina/InitrdPatcher.swift
+++ b/Sources/Lumina/InitrdPatcher.swift
@@ -38,11 +38,15 @@ enum InitrdPatcher {
             throw .bootFailed(underlying: PatcherError.readFailed("agent binary: \(error)"))
         }
 
-        // Read kernel modules (vsock etc.) if available
+        // Read kernel modules (vsock etc.) if available.
+        // Resolve symlinks first — FileManager.contentsOfDirectory(at: URL) returns
+        // ENOTDIR for symlinked directories on macOS, even when the target is a real
+        // directory. This breaks custom images whose modules dir symlinks to the base.
         var moduleFiles: [(name: String, data: Data)] = []
         if let modulesDir = modulesDir {
+            let resolvedDir = modulesDir.resolvingSymlinksInPath()
             let fm = FileManager.default
-            if let entries = try? fm.contentsOfDirectory(at: modulesDir, includingPropertiesForKeys: nil) {
+            if let entries = try? fm.contentsOfDirectory(at: resolvedDir, includingPropertiesForKeys: nil) {
                 for entry in entries.sorted(by: { $0.lastPathComponent < $1.lastPathComponent }) {
                     if entry.pathExtension == "gz" || entry.pathExtension == "ko" {
                         if let data = try? Data(contentsOf: entry) {

--- a/Sources/Lumina/Lumina.swift
+++ b/Sources/Lumina/Lumina.swift
@@ -89,6 +89,11 @@ public struct Lumina {
     }
 
     /// Create a custom image by running a command in a disposable VM.
+    /// Set `options.timeout` to control how long the build command can run (default 60s).
+    ///
+    /// Unlike `run`, this manages the VM lifecycle manually: after the build
+    /// command completes, the clone is detached, the VM is shut down cleanly
+    /// (flushing the ext4 journal), and then the rootfs is copied to the image store.
     public static func createImage(
         name: String,
         from base: String = "default",
@@ -97,19 +102,36 @@ public struct Lumina {
     ) async throws {
         var opts = options
         opts.image = base
-        let resolvedOpts = opts
-        try await withVM(options: resolvedOpts) { vm in
+        let vmOptions = VMOptions(from: opts)
+        let vm = VM(options: vmOptions)
+
+        // Phase 1: Run command (VM owns everything — shutdown handles cleanup on failure)
+        do {
             try await vm.bootResult().get()
-            let result = try await vm.execResult(command, timeout: Int(resolvedOpts.timeout.components.seconds), env: resolvedOpts.env).get()
-            guard result.success else {
-                throw LuminaError.sessionFailed("Image build command failed with exit code \(result.exitCode): \(result.stderr)")
-            }
-            guard let clone = await vm.diskClone else {
-                throw LuminaError.sessionFailed("No disk clone available")
-            }
-            let store = ImageStore()
-            try store.createImage(name: name, from: base, rootfsSource: clone.rootfs, command: command)
+        } catch {
+            await vm.shutdown()
+            throw error
         }
+        let result = try await vm.execResult(command, timeout: max(Int(opts.timeout.components.seconds), 1), env: opts.env).get()
+        guard result.success else {
+            await vm.shutdown()
+            throw LuminaError.sessionFailed("Image build command failed with exit code \(result.exitCode): \(result.stderr)")
+        }
+
+        // Phase 2: Transfer ownership — clone detached, VM shut down cleanly.
+        // After this point, WE own the clone and must clean it up.
+        guard let clone = await vm.detachClone() else {
+            await vm.shutdown()
+            throw LuminaError.sessionFailed("No disk clone available")
+        }
+        // Clean shutdown flushes the Virtualization framework's disk cache
+        // and the guest kernel's ext4 journal, producing a consistent rootfs.
+        await vm.shutdown()
+
+        // Phase 3: Copy rootfs into image store (caller owns clone)
+        defer { clone.remove() }
+        let store = ImageStore()
+        try store.createImage(name: name, from: base, rootfsSource: clone.rootfs, command: command)
     }
 
     /// Run a closure with a private network of VMs.

--- a/Sources/Lumina/SessionServer.swift
+++ b/Sources/Lumina/SessionServer.swift
@@ -159,7 +159,7 @@ public final class SessionServer: @unchecked Sendable {
     private func handleExec(cmd: String, timeout: Int, env: [String: String], vm: VM, handle: FileHandle) async {
         let start = ContinuousClock.now
         let result = await vm.execResult(cmd, timeout: timeout, env: env)
-        let ms = Int((ContinuousClock.now - start).components.seconds * 1000)
+        let ms = (ContinuousClock.now - start).totalMilliseconds
         switch result {
         case .success(let runResult):
             if !runResult.stdout.isEmpty {

--- a/Sources/Lumina/Types.swift
+++ b/Sources/Lumina/Types.swift
@@ -263,6 +263,17 @@ public enum LuminaError: Error, Sendable {
     case sessionFailed(String)
 }
 
+// MARK: - Duration Helpers
+
+extension Duration {
+    /// Total milliseconds from both seconds and attoseconds components.
+    /// Single definition to avoid fat-fingering the attosecond divisor.
+    /// Named `totalMilliseconds` to avoid conflict with `Duration.milliseconds(_:)`.
+    public var totalMilliseconds: Int {
+        Int(components.seconds * 1000 + components.attoseconds / 1_000_000_000_000_000)
+    }
+}
+
 // MARK: - Parsing Helpers
 
 /// Parse a human-readable duration string (e.g. "30s", "5m") into a Duration.

--- a/Sources/Lumina/VM.swift
+++ b/Sources/Lumina/VM.swift
@@ -380,6 +380,16 @@ public actor VM {
         await shutdownVM()
     }
 
+    /// Detach the disk clone from this VM. The caller takes ownership and is
+    /// responsible for cleanup. After detaching, shutdown() will NOT remove the
+    /// clone directory. Used by `createImage` to preserve the rootfs after a
+    /// clean VM shutdown.
+    public func detachClone() -> DiskClone? {
+        let c = clone
+        clone = nil
+        return c
+    }
+
     public var serialOutput: String {
         serialConsole.output
     }

--- a/Sources/lumina-cli/CLI.swift
+++ b/Sources/lumina-cli/CLI.swift
@@ -23,13 +23,16 @@ struct Run: AsyncParsableCommand {
     @Argument(help: "Command to run in the VM")
     var command: String
 
+    @Option(name: .long, help: "Image to boot from")
+    var image: String = "default"
+
     @Flag(name: .long, help: "Stream output in real time (NDJSON when piped, raw when TTY)")
     var stream = false
 
     @Flag(name: .long, help: "Force human-readable text output (default when TTY)")
     var text = false
 
-    @Option(name: .long, help: "Timeout (e.g. 30s, 5m)")
+    @Option(name: .long, help: "Command timeout, excludes ~2s boot time (e.g. 30s, 5m)")
     var timeout: String = "60s"
 
     @Option(name: .long, help: "Memory (e.g. 512MB, 1GB)")
@@ -166,6 +169,7 @@ struct Run: AsyncParsableCommand {
             timeout: parsedTimeout,
             memory: parsedMemory,
             cpuCount: cpus,
+            image: image,
             env: parsedEnv,
             uploads: parsedUploads,
             downloads: parsedDownloads,
@@ -206,7 +210,7 @@ struct Run: AsyncParsableCommand {
             let ms = millisSince(start)
             switch format {
             case .json:
-                printErrorJSON(error, durationMs: ms)
+                printErrorJSON(error, durationMs: ms, friendly: true)
             case .text:
                 try handleTextError(error, timeout: timeout)
             }
@@ -226,11 +230,11 @@ struct Run: AsyncParsableCommand {
                     // NDJSON: one JSON object per line
                     switch chunk {
                     case .stdout(let data):
-                        printNDJSON(["stream": "stdout", "data": data])
+                        printNDJSONLine(StreamChunk(stream: "stdout", data: data))
                     case .stderr(let data):
-                        printNDJSON(["stream": "stderr", "data": data])
+                        printNDJSONLine(StreamChunk(stream: "stderr", data: data))
                     case .exit(let code):
-                        printNDJSON(["exit_code": Int(code), "duration_ms": millisSince(start)])
+                        printNDJSONLine(ExitChunk(exit_code: Int(code), duration_ms: millisSince(start)))
                         if code != 0 { throw ExitCode(code) }
                     }
                 case .text:
@@ -249,7 +253,7 @@ struct Run: AsyncParsableCommand {
         } catch {
             switch format {
             case .json:
-                printNDJSON(["error": String(describing: error), "duration_ms": millisSince(start)])
+                printNDJSONLine(ErrorChunk(error: friendlyError(error), duration_ms: millisSince(start)))
             case .text:
                 try handleTextError(error, timeout: timeout)
             }
@@ -302,8 +306,9 @@ private func printResultJSON(_ result: RunResult, durationMs: Int) {
     encodeAndPrint(r)
 }
 
-private func printErrorJSON(_ error: any Error, durationMs: Int) {
-    let r = ResultJSON(error: String(describing: error), duration_ms: durationMs)
+private func printErrorJSON(_ error: any Error, durationMs: Int, friendly: Bool = false) {
+    let msg = friendly ? friendlyError(error) : String(describing: error)
+    let r = ResultJSON(error: msg, duration_ms: durationMs)
     encodeAndPrint(r)
 }
 
@@ -317,8 +322,7 @@ private func encodeAndPrint<T: Encodable>(_ value: T) {
 }
 
 private func millisSince(_ start: ContinuousClock.Instant) -> Int {
-    let elapsed = ContinuousClock.now - start
-    return Int(elapsed.components.seconds * 1000 + elapsed.components.attoseconds / 1_000_000_000_000_000)
+    (ContinuousClock.now - start).totalMilliseconds
 }
 
 // MARK: - Pull
@@ -389,10 +393,20 @@ struct ImageCreate: AsyncParsableCommand {
     @Option(name: [.customLong("run")], help: "Command to run for setup")
     var buildCommand: String
 
+    @Option(name: .long, help: "Timeout for build command (e.g. 60s, 5m)")
+    var timeout: String = "5m"
+
     func run() async throws {
+        guard let parsedTimeout = parseDuration(timeout) else {
+            FileHandle.standardError.write(Data("lumina: invalid timeout '\(timeout)'. Use e.g. 60s, 5m\n".utf8))
+            throw ExitCode.failure
+        }
+
         FileHandle.standardError.write(Data("Creating image '\(name)' from '\(from)'...\n".utf8))
         do {
-            try await Lumina.createImage(name: name, from: from, command: buildCommand)
+            var opts = RunOptions()
+            opts.timeout = parsedTimeout
+            try await Lumina.createImage(name: name, from: from, command: buildCommand, options: opts)
             print("Image '\(name)' created successfully.")
         } catch {
             FileHandle.standardError.write(Data("lumina: image create failed: \(error)\n".utf8))
@@ -428,14 +442,23 @@ struct ImageInspect: ParsableCommand {
     func run() throws {
         let store = ImageStore()
         let info = try store.inspect(name: name)
-        let dict: [String: Any] = [
-            "name": info.name,
-            "base": info.base ?? "none",
-            "command": info.command ?? "none",
-            "size_bytes": info.sizeBytes,
-            "created": ISO8601DateFormatter().string(from: info.created)
-        ]
-        if let data = try? JSONSerialization.data(withJSONObject: dict, options: [.sortedKeys, .prettyPrinted]),
+        struct ImageInspectOutput: Encodable {
+            var name: String
+            var base: String
+            var command: String
+            var size_bytes: UInt64
+            var created: String
+        }
+        let output = ImageInspectOutput(
+            name: info.name,
+            base: info.base ?? "none",
+            command: info.command ?? "none",
+            size_bytes: info.sizeBytes,
+            created: ISO8601DateFormatter().string(from: info.created)
+        )
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.sortedKeys, .prettyPrinted]
+        if let data = try? encoder.encode(output),
            let str = String(data: data, encoding: .utf8) {
             print(str)
         }
@@ -481,6 +504,9 @@ struct SessionStart: AsyncParsableCommand {
     @Option(name: .long, help: "Volume to mount (name:guest_path, repeatable)")
     var volume: [String] = []
 
+    @Option(name: .long, help: "Max time to wait for VM to boot (e.g. 30s, 2m)")
+    var bootTimeout: String = "60s"
+
     func run() async throws {
         // Auto-pull image if not present
         let puller = ImagePuller()
@@ -500,6 +526,12 @@ struct SessionStart: AsyncParsableCommand {
             FileHandle.standardError.write(Data("lumina: invalid memory '\(memory)'\n".utf8))
             throw ExitCode.failure
         }
+
+        guard let parsedBootTimeout = parseDuration(bootTimeout) else {
+            FileHandle.standardError.write(Data("lumina: invalid boot-timeout '\(bootTimeout)'. Use e.g. 30s, 2m\n".utf8))
+            throw ExitCode.failure
+        }
+        let bootTimeoutSecs = Int(parsedBootTimeout.components.seconds)
 
         var parsedVolumes: [VolumeMount] = []
         for spec in volume {
@@ -543,7 +575,7 @@ struct SessionStart: AsyncParsableCommand {
 
         // Wait for the socket to appear (session process boots VM)
         let paths = SessionPaths(sid: sid)
-        let deadline = ContinuousClock.now + .seconds(30)
+        let deadline = ContinuousClock.now + .seconds(bootTimeoutSecs)
         while ContinuousClock.now < deadline {
             if FileManager.default.fileExists(atPath: paths.socket.path) {
                 break
@@ -552,7 +584,7 @@ struct SessionStart: AsyncParsableCommand {
         }
 
         guard FileManager.default.fileExists(atPath: paths.socket.path) else {
-            FileHandle.standardError.write(Data("lumina: session failed to start within 30s\n".utf8))
+            FileHandle.standardError.write(Data("lumina: session failed to start within \(bootTimeout)\n".utf8))
             throw ExitCode.failure
         }
 
@@ -574,13 +606,37 @@ struct SessionStop: AsyncParsableCommand {
     @Argument(help: "Session ID")
     var sid: String
 
+    @Flag(name: .long, help: "Force human-readable text output")
+    var text = false
+
     func run() async throws {
         let client = SessionClient()
         do {
             try client.connect(sid: sid)
             try client.send(.shutdown)
-            _ = try? client.receive()
+            // Verify the server acknowledged the shutdown
+            let response = try? client.receive()
             client.disconnect()
+
+            let confirmed: Bool
+            if let response = response {
+                switch response {
+                case .exit: confirmed = true
+                default: confirmed = false
+                }
+            } else {
+                // Connection closed — server shut down (success)
+                confirmed = true
+            }
+
+            let format = resolveOutputFormat(textFlag: text)
+            switch format {
+            case .json:
+                struct StopResult: Encodable { var stopped: String; var confirmed: Bool }
+                encodeAndPrint(StopResult(stopped: sid, confirmed: confirmed))
+            case .text:
+                print("Session '\(sid)' stopped.")
+            }
         } catch let error as LuminaError {
             switch error {
             case .sessionNotFound:
@@ -713,7 +769,7 @@ struct Exec: AsyncParsableCommand {
             case .output(let outputStream, let data):
                 switch format {
                 case .json:
-                    printNDJSON(["stream": outputStream.rawValue, "data": data])
+                    printNDJSONLine(StreamChunk(stream: outputStream.rawValue, data: data))
                 case .text:
                     if outputStream == .stdout {
                         print(data, terminator: "")
@@ -724,7 +780,7 @@ struct Exec: AsyncParsableCommand {
             case .exit(let code, let durationMs):
                 switch format {
                 case .json:
-                    printNDJSON(["exit_code": Int(code), "duration_ms": durationMs])
+                    printNDJSONLine(ExitChunk(exit_code: Int(code), duration_ms: durationMs))
                 case .text:
                     break
                 }
@@ -811,13 +867,21 @@ struct VolumeInspect: ParsableCommand {
     func run() throws {
         let store = VolumeStore()
         let info = try store.inspect(name: name)
-        let dict: [String: Any] = [
-            "name": info.name,
-            "size_bytes": info.sizeBytes,
-            "created": ISO8601DateFormatter().string(from: info.created),
-            "last_used": ISO8601DateFormatter().string(from: info.lastUsed)
-        ]
-        if let data = try? JSONSerialization.data(withJSONObject: dict, options: [.sortedKeys, .prettyPrinted]),
+        struct VolumeInspectOutput: Encodable {
+            var name: String
+            var size_bytes: UInt64
+            var created: String
+            var last_used: String
+        }
+        let output = VolumeInspectOutput(
+            name: info.name,
+            size_bytes: info.sizeBytes,
+            created: ISO8601DateFormatter().string(from: info.created),
+            last_used: ISO8601DateFormatter().string(from: info.lastUsed)
+        )
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.sortedKeys, .prettyPrinted]
+        if let data = try? encoder.encode(output),
            let str = String(data: data, encoding: .utf8) {
             print(str)
         }

--- a/Sources/lumina-cli/Helpers.swift
+++ b/Sources/lumina-cli/Helpers.swift
@@ -2,6 +2,28 @@
 import Foundation
 import Lumina
 
+// MARK: - Error Descriptions
+
+/// Return a human-friendly description for LuminaError, adding context where possible.
+func friendlyError(_ error: any Error) -> String {
+    guard let luminaError = error as? LuminaError else {
+        return String(describing: error)
+    }
+    switch luminaError {
+    case .bootFailed(let underlying):
+        // Match on structured NSError domain/code, not fragile string content.
+        // ENOTSUP (45) in NSPOSIXErrorDomain means the Virtualization framework
+        // rejected the VM — typically because macOS hit its concurrent VM limit.
+        let nsError = underlying as NSError
+        if nsError.domain == NSPOSIXErrorDomain && nsError.code == Int(ENOTSUP) {
+            return "bootFailed: VM limit reached — macOS restricts the number of concurrent VMs. Reduce parallel runs or use sessions."
+        }
+        return String(describing: luminaError)
+    default:
+        return String(describing: luminaError)
+    }
+}
+
 // MARK: - Signal Handlers (shared across CLI commands)
 
 /// Install signal handlers via sigaction. Cleans orphaned COW clones on
@@ -59,16 +81,34 @@ func resolveOutputFormat(textFlag: Bool) -> OutputFormat {
     return isatty(STDOUT_FILENO) != 0 ? .text : .json
 }
 
-/// Print an NDJSON line (used for streaming output).
-func printNDJSON(_ dict: [String: Any]) {
-    // Use JSONSerialization for heterogeneous dicts, then ensure no literal newlines
-    guard let data = try? JSONSerialization.data(withJSONObject: dict, options: [.sortedKeys, .fragmentsAllowed]),
-          var str = String(data: data, encoding: .utf8) else { return }
-    // JSONSerialization doesn't escape newlines in string values -- replace them
-    str = str.replacingOccurrences(of: "\n", with: "\\n")
-    str = str.replacingOccurrences(of: "\r", with: "\\r")
-    str = str.replacingOccurrences(of: "\t", with: "\\t")
-    print(str)
-    // Flush stdout for real-time streaming
-    fflush(stdout)
+// MARK: - NDJSON Output Types (streaming / session exec)
+
+/// Stream chunk: stdout or stderr data.
+struct StreamChunk: Encodable {
+    var stream: String
+    var data: String
+}
+
+/// Exit status for streaming / session exec.
+struct ExitChunk: Encodable {
+    var exit_code: Int
+    var duration_ms: Int
+}
+
+/// Error for streaming / session exec.
+struct ErrorChunk: Encodable {
+    var error: String
+    var duration_ms: Int
+}
+
+/// Print a Codable value as a single NDJSON line, flushing immediately for real-time output.
+/// Uses JSONEncoder which always properly escapes control characters (\n, \r, \t, etc.).
+func printNDJSONLine<T: Encodable>(_ value: T) {
+    let encoder = JSONEncoder()
+    encoder.outputFormatting = .sortedKeys
+    if let data = try? encoder.encode(value),
+       let str = String(data: data, encoding: .utf8) {
+        print(str)
+        fflush(stdout)
+    }
 }


### PR DESCRIPTION
## Summary

- **Session exec JSON encoding**: replaced fragile `JSONSerialization` + manual escape with typed `Codable` structs + `JSONEncoder` — eliminates all control character escaping bugs
- **Custom image boot failure**: root-caused to `FileManager.contentsOfDirectory(at:)` not following symlinks on macOS; also fixed dirty rootfs via `detachClone()` + clean shutdown before copy
- **File downloads > 64KB**: rewrote guest agent to stream from disk in 48KB chunks instead of `os.ReadFile`
- **CLI gaps**: added `--image` on `run`, `--timeout` on `images create`, `--boot-timeout` on `session start`, confirmation on `session stop`
- **Duration tracking**: `Duration.totalMilliseconds` extension fixes sub-second truncation to 0ms
- **Error matching**: `friendlyError` uses structured `NSError` domain/code, not string matching
- **Inspect commands**: migrated `ImageInspect` + `VolumeInspect` from `JSONSerialization` to typed `Codable` structs

8 files changed, 244 insertions, 70 deletions.

## Test plan

- [x] `make build` — clean, zero errors
- [x] `make test` — 87 tests pass
- [x] Guest agent cross-compiles (`linux/arm64`)
- [x] Session exec JSON: jq parses multi-line output with `\n`, `\t`, `\"`
- [x] Custom image: create python image, boot via `run --image` and `session start --image`, Python 3.12.12 runs
- [x] File upload: 5MB integrity verified (MD5 match)
- [x] File download: small file round-trip works
- [x] Volumes: state persists across runs
- [x] Mounts: bidirectional host↔guest
- [x] Streaming: valid NDJSON, jq exit 0
- [x] Concurrent: 5 parallel VMs in 2.3s
- [x] Session stop: `{"confirmed":true,"stopped":"<sid>"}`
- [x] Duration: 3ms fast, 1006ms for 1s sleep
- [x] All CLI flags present and functional

🤖 Generated with [Claude Code](https://claude.com/claude-code)