### PR TITLE
feat: session streaming + parseDuration hours

### DIFF
--- a/Sources/Lumina/SessionServer.swift
+++ b/Sources/Lumina/SessionServer.swift
@@ -158,18 +158,22 @@ public final class SessionServer: @unchecked Sendable {
 
     private func handleExec(cmd: String, timeout: Int, env: [String: String], vm: VM, handle: FileHandle) async {
         let start = ContinuousClock.now
-        let result = await vm.execResult(cmd, timeout: timeout, env: env)
-        let ms = (ContinuousClock.now - start).totalMilliseconds
-        switch result {
-        case .success(let runResult):
-            if !runResult.stdout.isEmpty {
-                try? writeResponse(.output(stream: .stdout, data: runResult.stdout), to: handle)
+        do {
+            // Stream output in real time — each chunk is sent to the client as it arrives
+            // from the guest agent, rather than buffering the entire result.
+            let chunks = try await vm.stream(cmd, timeout: timeout, env: env)
+            for try await chunk in chunks {
+                switch chunk {
+                case .stdout(let data):
+                    try? writeResponse(.output(stream: .stdout, data: data), to: handle)
+                case .stderr(let data):
+                    try? writeResponse(.output(stream: .stderr, data: data), to: handle)
+                case .exit(let code):
+                    let ms = (ContinuousClock.now - start).totalMilliseconds
+                    try? writeResponse(.exit(code: code, durationMs: ms), to: handle)
+                }
             }
-            if !runResult.stderr.isEmpty {
-                try? writeResponse(.output(stream: .stderr, data: runResult.stderr), to: handle)
-            }
-            try? writeResponse(.exit(code: runResult.exitCode, durationMs: ms), to: handle)
-        case .failure(let error):
+        } catch {
             try? writeResponse(.error(message: String(describing: error)), to: handle)
         }
     }

--- a/Sources/Lumina/Types.swift
+++ b/Sources/Lumina/Types.swift
@@ -276,7 +276,7 @@ extension Duration {
 
 // MARK: - Parsing Helpers
 
-/// Parse a human-readable duration string (e.g. "30s", "5m") into a Duration.
+/// Parse a human-readable duration string (e.g. "30s", "5m", "2h") into a Duration.
 /// Returns nil on invalid input. Bare numbers are treated as seconds.
 public func parseDuration(_ str: String) -> Duration? {
     let trimmed = str.trimmingCharacters(in: .whitespaces).lowercased()
@@ -286,6 +286,9 @@ public func parseDuration(_ str: String) -> Duration? {
     } else if trimmed.hasSuffix("m") {
         guard let num = Int(trimmed.dropLast()) else { return nil }
         return .seconds(num * 60)
+    } else if trimmed.hasSuffix("h") {
+        guard let num = Int(trimmed.dropLast()) else { return nil }
+        return .seconds(num * 3600)
     }
     guard let num = Int(trimmed) else { return nil }
     return .seconds(num)

--- a/Tests/LuminaTests/ParsingTests.swift
+++ b/Tests/LuminaTests/ParsingTests.swift
@@ -13,6 +13,12 @@ import Testing
     #expect(parseDuration("1m") == .seconds(60))
 }
 
+@Test func parseDurationHours() {
+    #expect(parseDuration("1h") == .seconds(3600))
+    #expect(parseDuration("2h") == .seconds(7200))
+    #expect(parseDuration("24h") == .seconds(86400))
+}
+
 @Test func parseDurationBareNumber() {
     #expect(parseDuration("30") == .seconds(30))
     #expect(parseDuration("0") == .seconds(0))
@@ -23,6 +29,7 @@ import Testing
     #expect(parseDuration("") == nil)
     #expect(parseDuration("s") == nil)
     #expect(parseDuration("m") == nil)
+    #expect(parseDuration("h") == nil)
     #expect(parseDuration("12x") == nil)
 }
 


### PR DESCRIPTION
## Summary

- **Session streaming (P0)**: `SessionServer.handleExec` now uses `vm.stream()` instead of `vm.execResult()`. Output chunks are sent to the client in real time as they arrive from the guest agent. Agents no longer wait blind during long commands.
- **parseDuration hours (P1)**: Added `h` suffix support — `--timeout 1h` now works for long builds/tests.
- Added `parseDurationHours` unit test.

## Test plan

- [x] 88 tests pass (was 87)
- [x] Session exec streams 3 lines 1 second apart — each arrives as separate NDJSON chunk
- [x] `--timeout 1h` accepted and parses to 3600s
- [x] `parseDuration("h")` returns nil (bare suffix rejected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)