### PR TITLE
perf+feat+fix: five audit wins + bug fix + cleanups

### DIFF
--- a/Guest/build-image.sh
+++ b/Guest/build-image.sh
@@ -252,8 +252,10 @@ fi
   # (Layer 3 — Lifecycle in the three-layer API) MUST call
   # `vm.configureNetwork()` themselves before the first exec
   # if they need NAT eth0 outbound (DNS, internet). Skipping
-  # it leaves eth0 with carrier UP and no IP — traffic out the
-  # default route will fail. See the docstring on `VM.boot()`.
+  # it leaves eth0 admin-down with no IP/route — traffic out
+  # the default route will fail. See the docstring on
+  # `VM.boot()`. configureNetwork() brings eth0 up via
+  # `ip link set eth0 up` and assigns the IP/route over vsock.
 
   # Private networking config — LUMINA_NET_IP / LUMINA_HOSTS were parsed
   # from /proc/cmdline at init start (outer scope).

--- a/Guest/build-image.sh
+++ b/Guest/build-image.sh
@@ -232,15 +232,20 @@ fi
     n=$((n+1))
   done
 
-  # Disable IPv6 — VZ NAT only provides IPv4 routing
+  # Disable IPv6 — VZ NAT only provides IPv4 routing.
+  # The host-side `configure_network` (network.go) does this too;
+  # keeping it here so eth0 stays sane even if the host driver
+  # doesn't run (e.g. custom library callers that skip
+  # `vm.configureNetwork()`).
   echo 1 > /proc/sys/net/ipv6/conf/all/disable_ipv6 2>/dev/null
 
-  # DHCP — let vmnet assign the correct IP and gateway.
-  # Static MAC-derived IPs hardcoded the subnet to 192.168.64.0/24, but
-  # vmnet will pick a different range (e.g. 192.168.65.0/24) when that
-  # range is already in use by another interface or VPN. DHCP always gets
-  # the right subnet regardless of which one vmnet chose.
-  udhcpc -i eth0 -t 5 -T 1 -n -q -s /usr/share/udhcpc/default.script 2>/dev/null
+  # NOTE: udhcpc was previously invoked here as a fallback DHCP
+  # client. Removed in v0.7.2 — the host driver always sends
+  # `configure_network` over vsock (Lumina.run, Lumina.stream,
+  # Lumina.createImage, SessionProcess, Pool, Network all call it),
+  # which is faster and authoritative. udhcpc raced the host
+  # driver, occasionally installed a different IP/route than the
+  # host requested, and added 30–80 ms of churn on every boot.
 
   # Private networking config — LUMINA_NET_IP / LUMINA_HOSTS were parsed
   # from /proc/cmdline at init start (outer scope).

--- a/Guest/build-image.sh
+++ b/Guest/build-image.sh
@@ -240,12 +240,20 @@ fi
   echo 1 > /proc/sys/net/ipv6/conf/all/disable_ipv6 2>/dev/null
 
   # NOTE: udhcpc was previously invoked here as a fallback DHCP
-  # client. Removed in v0.7.2 — the host driver always sends
-  # `configure_network` over vsock (Lumina.run, Lumina.stream,
-  # Lumina.createImage, SessionProcess, Pool, Network all call it),
-  # which is faster and authoritative. udhcpc raced the host
-  # driver, occasionally installed a different IP/route than the
-  # host requested, and added 30–80 ms of churn on every boot.
+  # client. Removed in v0.7.2 — every internal caller of `VM`
+  # (Lumina.run, Lumina.stream, Lumina.createImage,
+  # SessionProcess, Pool, Network) drives `configure_network`
+  # over vsock, which is faster and authoritative. udhcpc raced
+  # the host driver, occasionally installed a different IP/route
+  # than the host requested, and added 30–80 ms of churn on
+  # every boot.
+  #
+  # Library callers using the public `VM` actor directly
+  # (Layer 3 — Lifecycle in the three-layer API) MUST call
+  # `vm.configureNetwork()` themselves before the first exec
+  # if they need NAT eth0 outbound (DNS, internet). Skipping
+  # it leaves eth0 with carrier UP and no IP — traffic out the
+  # default route will fail. See the docstring on `VM.boot()`.
 
   # Private networking config — LUMINA_NET_IP / LUMINA_HOSTS were parsed
   # from /proc/cmdline at init start (outer scope).

--- a/Guest/lumina-agent/internal/protocol/protocol.go
+++ b/Guest/lumina-agent/internal/protocol/protocol.go
@@ -148,12 +148,18 @@ type PortForwardStopMsg struct {
 
 // ── Guest → host messages ──────────────────────────────────────────
 
+// Version is the wire-format version this agent speaks. Typed (not
+// a bare int) so future v2 branching is greppable and `go vet`
+// flags missed comparison sites. JSON-encodes as a plain integer —
+// no migration on the wire.
+type Version int
+
 // ProtocolVersion is the wire-format version this agent speaks.
 // Bump on any breaking wire change so the host can branch cleanly
 // (or refuse to talk to a too-old/too-new agent) instead of
 // guessing from message-shape probing. Old agents predate this
 // field and the host treats absence as version=0.
-const ProtocolVersion = 1
+const ProtocolVersion Version = 1
 
 // AgentCapabilities is the conservative list of message families
 // this build of the agent implements. The host may consult it
@@ -173,7 +179,7 @@ var AgentCapabilities = []string{
 
 type ReadyMsg struct {
 	Type            string   `json:"type"`
-	ProtocolVersion int      `json:"protocol_version,omitempty"`
+	ProtocolVersion Version  `json:"protocol_version,omitempty"`
 	Capabilities    []string `json:"capabilities,omitempty"`
 }
 

--- a/Guest/lumina-agent/internal/protocol/protocol.go
+++ b/Guest/lumina-agent/internal/protocol/protocol.go
@@ -148,11 +148,42 @@ type PortForwardStopMsg struct {
 
 // ── Guest → host messages ──────────────────────────────────────────
 
-type ReadyMsg struct {
-	Type string `json:"type"`
+// ProtocolVersion is the wire-format version this agent speaks.
+// Bump on any breaking wire change so the host can branch cleanly
+// (or refuse to talk to a too-old/too-new agent) instead of
+// guessing from message-shape probing. Old agents predate this
+// field and the host treats absence as version=0.
+const ProtocolVersion = 1
+
+// AgentCapabilities is the conservative list of message families
+// this build of the agent implements. The host may consult it
+// before issuing a `pty_exec` or `port_forward_start` against an
+// older guest. Adding a capability is non-breaking (older hosts
+// ignore unknown strings); removing one IS breaking and must be
+// paired with a ProtocolVersion bump.
+var AgentCapabilities = []string{
+	"pty",              // pty_exec / pty_input / pty_output / window_resize
+	"port_forward",     // port_forward_start / stop / ready / error
+	"network_metrics",  // periodic network_metrics frames
+	"network_error",    // typed network_error on configure_network failure
+	"binary_output",    // base64-encoded output for non-UTF-8 chunks
+	"configure_network",
+	"stdin",
 }
 
-func NewReady() ReadyMsg { return ReadyMsg{Type: TypeReady} }
+type ReadyMsg struct {
+	Type            string   `json:"type"`
+	ProtocolVersion int      `json:"protocol_version,omitempty"`
+	Capabilities    []string `json:"capabilities,omitempty"`
+}
+
+func NewReady() ReadyMsg {
+	return ReadyMsg{
+		Type:            TypeReady,
+		ProtocolVersion: ProtocolVersion,
+		Capabilities:    AgentCapabilities,
+	}
+}
 
 type HeartbeatMsg struct {
 	Type string `json:"type"`

--- a/Guest/lumina-agent/internal/protocol/protocol_test.go
+++ b/Guest/lumina-agent/internal/protocol/protocol_test.go
@@ -145,6 +145,51 @@ func TestPortForwardReadyMsg_HasExpectedShape(t *testing.T) {
 	}
 }
 
+func TestNewReady_PopulatesProtocolVersionAndCapabilities(t *testing.T) {
+	msg := NewReady()
+	if msg.Type != TypeReady {
+		t.Errorf("expected type=ready, got %q", msg.Type)
+	}
+	if msg.ProtocolVersion != ProtocolVersion {
+		t.Errorf("expected protocol_version=%d, got %d", ProtocolVersion, msg.ProtocolVersion)
+	}
+	if len(msg.Capabilities) == 0 {
+		t.Errorf("expected non-empty capabilities, got %v", msg.Capabilities)
+	}
+	// Wire-shape lock: ensure a few load-bearing capabilities make it
+	// onto the frame so a future refactor can't silently drop one.
+	required := []string{"pty", "port_forward", "network_metrics", "binary_output"}
+	for _, want := range required {
+		found := false
+		for _, c := range msg.Capabilities {
+			if c == want {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("expected capability %q in NewReady(), got %v", want, msg.Capabilities)
+		}
+	}
+}
+
+func TestReadyMsg_OmitsEmptyOptionalFields(t *testing.T) {
+	// A literal ReadyMsg with zero values must marshal without
+	// protocol_version/capabilities so old hosts that don't
+	// recognise the fields stay quiet — `omitempty` is the
+	// backward-compat guarantee.
+	bare := ReadyMsg{Type: TypeReady}
+	data, _ := json.Marshal(bare)
+	asMap := map[string]any{}
+	_ = json.Unmarshal(data, &asMap)
+	if _, present := asMap["protocol_version"]; present {
+		t.Errorf("expected protocol_version omitted on zero, got present in %v", asMap)
+	}
+	if _, present := asMap["capabilities"]; present {
+		t.Errorf("expected capabilities omitted on nil, got present in %v", asMap)
+	}
+}
+
 func TestNewExit_BuildsCorrectDiscriminator(t *testing.T) {
 	msg := NewExit("xyz", 42)
 	if msg.Type != TypeExit {

--- a/Sources/Lumina/CommandRunner.swift
+++ b/Sources/Lumina/CommandRunner.swift
@@ -61,35 +61,26 @@ final class CommandRunner: @unchecked Sendable {
     private var _guestProtocolVersion: Int = 0
     private var _guestCapabilities: [String] = []
 
-    // ── Late-exit stash (v0.7.2) ──
-    // Audit-flagged correctness fix: `dispatchMessage` previously
-    // dropped any `.exit(id:code:)` whose id was not in
-    // `execHandlers` or `ptyHandlers`. Combined with the timeout
-    // watchdog, a slow command finishing a hair after timeout could
-    // lose its exit code — host returned `timeout`, guest had
-    // returned 0. Agents retrying non-idempotent ops did the work
-    // twice without any signal that they had.
+    // ── Late-exit grace window (v0.7.2) ──
+    // Audit-flagged correctness fix: a slow command finishing a
+    // hair after the timeout watchdog fired could lose its exit
+    // code — host returned `timeout`, guest had already returned 0.
+    // Agents retrying non-idempotent ops did the work twice with
+    // no signal that they had.
     //
-    // Two-part fix in this file:
-    //   1. dispatchMessage now stashes orphan exits here keyed by
-    //      id instead of dropping them.
-    //   2. exec() / execStream() use a soft/hard deadline pattern:
-    //      the watchdog fires SIGTERM at the soft deadline, but the
-    //      loop keeps reading the stream until the hard deadline
-    //      (soft + lateExitGraceWindow). A natural exit during the
-    //      grace window beats the synthetic timeout.
+    // Fix: `exec()` / `execStream()` use a soft/hard deadline
+    // pattern. The watchdog fires SIGTERM at the soft deadline
+    // (T+timeout) and wakes the loop, but the loop keeps reading
+    // the stream until the hard deadline (soft + grace window).
+    // A natural `.exit` during the grace window beats the
+    // synthetic timeout — the handler is still registered, so
+    // the dispatcher routes the message into the same stream
+    // we're still reading.
     //
-    // Bounded: pruned to entries inserted within `recentExitTTL`.
-    // Memory ceiling ~32 entries × ~24 B → trivial.
-    private struct StashedExit { let code: Int32; let when: ContinuousClock.Instant }
-    private var _recentExits: [String: StashedExit] = [:]
-    private static let recentExitTTL: Duration = .seconds(30)
-    /// Window after a soft timeout during which a natural `.exit`
-    /// from the guest beats the synthetic timeout error. Picked at
-    /// 250 ms because the typical guest-side cancel→exit RTT is
-    /// well under 50 ms; 250 ms covers the 95th-percentile
-    /// "command was about to exit anyway" race without making
-    /// genuine timeouts feel sluggish.
+    // 250 ms picked because the typical guest-side cancel→exit
+    // RTT is well under 50 ms; 250 ms covers the 95th-percentile
+    // "command was about to exit anyway" race without making
+    // genuine timeouts feel sluggish.
     private static let lateExitGraceWindow: Duration = .milliseconds(250)
 
     // ── Port forward continuations: one per in-flight port_forward_start ──
@@ -931,7 +922,7 @@ final class CommandRunner: @unchecked Sendable {
             let handler = ptyHandlers[id]
             ptyLock.unlock()
             handler?.yield(msg)
-        case .exit(let id, let code):
+        case .exit(let id, _):
             // Check exec handlers first (common case)
             lock.lock()
             let execHandler = execHandlers[id]
@@ -948,11 +939,13 @@ final class CommandRunner: @unchecked Sendable {
                 h.yield(msg)
                 break
             }
-            // Orphan exit: handler already unregistered (most likely a
-            // command exiting just after the timeout watchdog fired).
-            // Stash so the timeout path in `exec()` can claim it during
-            // its grace window instead of dropping the code.
-            stashLateExit(id: id, code: code)
+            // Orphan exit: handler already unregistered. Drop.
+            // Pre-fix this was the silent-loss path; the soft/hard
+            // deadline grace window in `exec()` keeps the handler
+            // registered through the natural-exit window, so by the
+            // time we land here the command genuinely overshot the
+            // window and the synthetic .timeout error is correct.
+            break
         case .heartbeat:
             // Broadcast to all exec handlers so timeout checks can run
             lock.lock()
@@ -1187,30 +1180,6 @@ final class CommandRunner: @unchecked Sendable {
         _guestProtocolVersion = protocolVersion
         _guestCapabilities = capabilities
         lock.unlock()
-    }
-
-    /// Record an orphan exit for later claim. Prunes expired entries
-    /// on every insert so the stash size stays bounded by
-    /// `recentExitTTL`.
-    private func stashLateExit(id: String, code: Int32) {
-        let now = ContinuousClock.now
-        lock.lock()
-        for (k, v) in _recentExits where v.when < now - Self.recentExitTTL {
-            _recentExits.removeValue(forKey: k)
-        }
-        _recentExits[id] = StashedExit(code: code, when: now)
-        lock.unlock()
-    }
-
-    /// Atomically remove and return a stashed exit code if one
-    /// arrived for `id` after the handler was unregistered. Called
-    /// from post-mortem reclaim paths. Returns nil when no late
-    /// exit has been recorded — that's the genuine-timeout path.
-    func consumeRecentExit(id: String) -> Int32? {
-        lock.lock()
-        defer { lock.unlock() }
-        guard let entry = _recentExits.removeValue(forKey: id) else { return nil }
-        return entry.code
     }
 
     /// Store a new vsock connection and create file handles for I/O.

--- a/Sources/Lumina/CommandRunner.swift
+++ b/Sources/Lumina/CommandRunner.swift
@@ -61,6 +61,37 @@ final class CommandRunner: @unchecked Sendable {
     private var _guestProtocolVersion: Int = 0
     private var _guestCapabilities: [String] = []
 
+    // ── Late-exit stash (v0.7.2) ──
+    // Audit-flagged correctness fix: `dispatchMessage` previously
+    // dropped any `.exit(id:code:)` whose id was not in
+    // `execHandlers` or `ptyHandlers`. Combined with the timeout
+    // watchdog, a slow command finishing a hair after timeout could
+    // lose its exit code — host returned `timeout`, guest had
+    // returned 0. Agents retrying non-idempotent ops did the work
+    // twice without any signal that they had.
+    //
+    // Two-part fix in this file:
+    //   1. dispatchMessage now stashes orphan exits here keyed by
+    //      id instead of dropping them.
+    //   2. exec() / execStream() use a soft/hard deadline pattern:
+    //      the watchdog fires SIGTERM at the soft deadline, but the
+    //      loop keeps reading the stream until the hard deadline
+    //      (soft + lateExitGraceWindow). A natural exit during the
+    //      grace window beats the synthetic timeout.
+    //
+    // Bounded: pruned to entries inserted within `recentExitTTL`.
+    // Memory ceiling ~32 entries × ~24 B → trivial.
+    private struct StashedExit { let code: Int32; let when: ContinuousClock.Instant }
+    private var _recentExits: [String: StashedExit] = [:]
+    private static let recentExitTTL: Duration = .seconds(30)
+    /// Window after a soft timeout during which a natural `.exit`
+    /// from the guest beats the synthetic timeout error. Picked at
+    /// 250 ms because the typical guest-side cancel→exit RTT is
+    /// well under 50 ms; 250 ms covers the 95th-percentile
+    /// "command was about to exit anyway" race without making
+    /// genuine timeouts feel sluggish.
+    private static let lateExitGraceWindow: Duration = .milliseconds(250)
+
     // ── Port forward continuations: one per in-flight port_forward_start ──
     // Keyed by guestPort. Throwing so teardown (reset/dispatcher error) can
     // surface `.connectionFailed` to the caller instead of silently succeeding
@@ -210,25 +241,44 @@ final class CommandRunner: @unchecked Sendable {
         // nil and RunResult.stdoutBytes/stderrBytes are nil.
         var stdoutBytes: Data? = nil
         var stderrBytes: Data? = nil
-        let deadline = ContinuousClock.now + .seconds(timeout)
 
-        // Precision watchdog: guest heartbeats arrive every 2s, so a deadline
-        // shorter than two heartbeats would never be checked promptly. This task
-        // fires at exactly `timeout` seconds, cancels the guest command, and
-        // injects a synthetic heartbeat to unblock the for-await loop below.
+        // Two deadlines (v0.7.2 audit follow-up):
+        //
+        //   softDeadline = T+timeout   — watchdog fires SIGTERM here and
+        //                                 wakes the loop, but we keep
+        //                                 reading the stream looking
+        //                                 for a natural exit.
+        //   hardDeadline = soft+grace  — only here do we throw `.timeout`.
+        //
+        // The grace window between them lets a command that finished
+        // a hair after the timeout fired report its real exit code
+        // instead of getting a synthetic timeout error. Without this,
+        // agents retrying non-idempotent operations could repeat work
+        // that actually succeeded.
+        let softDeadline = ContinuousClock.now + .seconds(timeout)
+        let hardDeadline = softDeadline + Self.lateExitGraceWindow
+
+        // Watchdog: two wakeups. First at soft deadline (send cancel +
+        // wake the loop so it stops blocking on for-await). Second at
+        // hard deadline (wake the loop again so it sees `now > hard`
+        // and throws — without this, the loop would block forever if
+        // no late exit arrives during grace).
         let watchdogId = id
         let watchdog = Task.detached { [weak self] in
             do { try await Task.sleep(for: .seconds(timeout)) } catch { return }
             guard let self else { return }
             try? self.cancel(id: watchdogId, signal: 15, gracePeriod: 5)
             self.yieldSyntheticHeartbeat(to: watchdogId)
+            do { try await Task.sleep(for: Self.lateExitGraceWindow) } catch { return }
+            self.yieldSyntheticHeartbeat(to: watchdogId)
         }
         defer { watchdog.cancel() }
 
         for await msg in stream {
-            if ContinuousClock.now > deadline {
-                // Send cancel to clean up the guest side (watchdog may have
-                // already sent it — cancel is idempotent on the guest).
+            if ContinuousClock.now > hardDeadline {
+                // Grace window expired without a natural exit. Genuine
+                // timeout — cancel is idempotent so an extra send here
+                // is fine if the watchdog already fired one.
                 try? cancel(id: id, signal: 15, gracePeriod: 5)
                 throw .timeout
             }
@@ -304,14 +354,30 @@ final class CommandRunner: @unchecked Sendable {
         let execId = id
 
         return AsyncThrowingStream { continuation in
+            // Soft/hard deadline pattern — same rationale as `exec()`.
+            // Soft deadline fires the cancel; hard deadline + grace
+            // window is when we actually throw timeout. Lets a natural
+            // exit racing the watchdog still report its real code.
+            let softDeadline = ContinuousClock.now + .seconds(timeout)
+            let hardDeadline = softDeadline + Self.lateExitGraceWindow
+
+            let watchdog = Task.detached { [weak runner] in
+                do { try await Task.sleep(for: .seconds(timeout)) } catch { return }
+                guard let runner else { return }
+                try? runner.cancel(id: execId, signal: 15, gracePeriod: 5)
+                runner.yieldSyntheticHeartbeat(to: execId)
+                do { try await Task.sleep(for: Self.lateExitGraceWindow) } catch { return }
+                runner.yieldSyntheticHeartbeat(to: execId)
+            }
+
             let task = Task.detached {
-                let deadline = ContinuousClock.now + .seconds(timeout)
                 for await msg in msgStream {
                     if Task.isCancelled {
                         continuation.finish()
                         return
                     }
-                    if ContinuousClock.now > deadline {
+                    if ContinuousClock.now > hardDeadline {
+                        // Cancel is idempotent on the guest side.
                         try? runner.cancel(id: execId, signal: 15, gracePeriod: 5)
                         continuation.finish(throwing: LuminaError.timeout)
                         return
@@ -334,6 +400,7 @@ final class CommandRunner: @unchecked Sendable {
 
             continuation.onTermination = { @Sendable _ in
                 task.cancel()
+                watchdog.cancel()
                 runner.unregisterExecHandler(execId)
             }
         }
@@ -864,7 +931,7 @@ final class CommandRunner: @unchecked Sendable {
             let handler = ptyHandlers[id]
             ptyLock.unlock()
             handler?.yield(msg)
-        case .exit(let id, _):
+        case .exit(let id, let code):
             // Check exec handlers first (common case)
             lock.lock()
             let execHandler = execHandlers[id]
@@ -877,7 +944,15 @@ final class CommandRunner: @unchecked Sendable {
             ptyLock.lock()
             let ptyHandler = ptyHandlers[id]
             ptyLock.unlock()
-            ptyHandler?.yield(msg)
+            if let h = ptyHandler {
+                h.yield(msg)
+                break
+            }
+            // Orphan exit: handler already unregistered (most likely a
+            // command exiting just after the timeout watchdog fired).
+            // Stash so the timeout path in `exec()` can claim it during
+            // its grace window instead of dropping the code.
+            stashLateExit(id: id, code: code)
         case .heartbeat:
             // Broadcast to all exec handlers so timeout checks can run
             lock.lock()
@@ -1112,6 +1187,30 @@ final class CommandRunner: @unchecked Sendable {
         _guestProtocolVersion = protocolVersion
         _guestCapabilities = capabilities
         lock.unlock()
+    }
+
+    /// Record an orphan exit for later claim. Prunes expired entries
+    /// on every insert so the stash size stays bounded by
+    /// `recentExitTTL`.
+    private func stashLateExit(id: String, code: Int32) {
+        let now = ContinuousClock.now
+        lock.lock()
+        for (k, v) in _recentExits where v.when < now - Self.recentExitTTL {
+            _recentExits.removeValue(forKey: k)
+        }
+        _recentExits[id] = StashedExit(code: code, when: now)
+        lock.unlock()
+    }
+
+    /// Atomically remove and return a stashed exit code if one
+    /// arrived for `id` after the handler was unregistered. Called
+    /// from post-mortem reclaim paths. Returns nil when no late
+    /// exit has been recorded — that's the genuine-timeout path.
+    func consumeRecentExit(id: String) -> Int32? {
+        lock.lock()
+        defer { lock.unlock() }
+        guard let entry = _recentExits.removeValue(forKey: id) else { return nil }
+        return entry.code
     }
 
     /// Store a new vsock connection and create file handles for I/O.

--- a/Sources/Lumina/CommandRunner.swift
+++ b/Sources/Lumina/CommandRunner.swift
@@ -53,6 +53,14 @@ final class CommandRunner: @unchecked Sendable {
     // command beat the ticker's 500ms initial delay, or legacy agent).
     private var _latestNetworkMetrics: NetworkMetricsSummary?
 
+    // ── Guest handshake metadata (v0.7.2) ──
+    // Captured from the agent's `ready` frame. 0 / [] when the guest
+    // pre-dates capability negotiation (older release tarballs).
+    // Diagnostic only today; future protocol bumps can branch on
+    // these to refuse incompatible guests instead of misdecoding.
+    private var _guestProtocolVersion: Int = 0
+    private var _guestCapabilities: [String] = []
+
     // ── Port forward continuations: one per in-flight port_forward_start ──
     // Keyed by guestPort. Throwing so teardown (reset/dispatcher error) can
     // surface `.connectionFailed` to the caller instead of silently succeeding
@@ -74,6 +82,23 @@ final class CommandRunner: @unchecked Sendable {
         lock.lock()
         defer { lock.unlock() }
         return _latestNetworkMetrics
+    }
+
+    /// Wire-format version reported by the guest on its `ready` frame.
+    /// 0 means the guest pre-dates v0.7.2 (no protocol_version field
+    /// in its `ready`). Thread-safe read.
+    var guestProtocolVersion: Int {
+        lock.lock()
+        defer { lock.unlock() }
+        return _guestProtocolVersion
+    }
+
+    /// Capability strings reported by the guest on its `ready` frame.
+    /// Empty when the guest pre-dates v0.7.2. Thread-safe read.
+    var guestCapabilities: [String] {
+        lock.lock()
+        defer { lock.unlock() }
+        return _guestCapabilities
     }
 
     var state: ConnectionState {
@@ -143,10 +168,15 @@ final class CommandRunner: @unchecked Sendable {
             setState(.disconnected)
             throw .protocolError("Failed to decode guest message: \(error)")
         }
-        guard msg == .ready else {
+        guard case .ready(let protocolVersion, let capabilities) = msg else {
             setState(.disconnected)
             throw .protocolError("Expected ready message, got: \(msg)")
         }
+
+        // Stash handshake metadata for diagnostics + future capability
+        // gating. v0.7.2+ agents populate these; older guests omit the
+        // fields and decode as (0, []) which is fine.
+        setHandshakeMetadata(protocolVersion: protocolVersion, capabilities: capabilities)
 
         setState(.ready)
         startDispatcher(initialBuffer: readBuffer)
@@ -1070,6 +1100,17 @@ final class CommandRunner: @unchecked Sendable {
     private func setState(_ newState: ConnectionState) {
         lock.lock()
         _state = newState
+        lock.unlock()
+    }
+
+    /// Sync wrapper so async callers (connect) can stash the guest's
+    /// handshake metadata without touching the NSLock directly —
+    /// `lock.lock()` is unavailable from async contexts under Swift 6
+    /// strict concurrency.
+    private func setHandshakeMetadata(protocolVersion: Int, capabilities: [String]) {
+        lock.lock()
+        _guestProtocolVersion = protocolVersion
+        _guestCapabilities = capabilities
         lock.unlock()
     }
 

--- a/Sources/Lumina/CommandRunner.swift
+++ b/Sources/Lumina/CommandRunner.swift
@@ -940,11 +940,20 @@ final class CommandRunner: @unchecked Sendable {
                 break
             }
             // Orphan exit: handler already unregistered. Drop.
-            // Pre-fix this was the silent-loss path; the soft/hard
-            // deadline grace window in `exec()` keeps the handler
-            // registered through the natural-exit window, so by the
-            // time we land here the command genuinely overshot the
-            // window and the synthetic .timeout error is correct.
+            // For `exec()` / `execStream()`: the soft/hard deadline
+            // grace window keeps the handler registered through the
+            // natural-exit window, so by the time we land here the
+            // command genuinely overshot the window and the synthetic
+            // .timeout error is correct.
+            // For `ptyExec()`: there is no host-side soft/hard
+            // deadline pattern — PTY timeout is enforced solely by
+            // the guest's gracefulKill (SIGTERM, then SIGKILL after
+            // 5s). A late PTY exit can therefore land here if the
+            // consumer cancelled or dropped the stream. This drop is
+            // bounded by the guest's SIGKILL fallback so the process
+            // can't outlive the host's cleanup; the PTY stream
+            // closes either way. Pre-existing — not introduced by
+            // the soft/hard deadline change.
             break
         case .heartbeat:
             // Broadcast to all exec handlers so timeout checks can run

--- a/Sources/Lumina/Lumina.swift
+++ b/Sources/Lumina/Lumina.swift
@@ -93,13 +93,13 @@ public struct Lumina {
                         try await vm.boot()
                         let bootDone = ContinuousClock.now
 
-                        // v0.7.1 perf: default awaits network_ready so
-                        // commands that need DNS/TCP in the first ~20ms
-                        // of exec work. Opt-out via
-                        // options.awaitNetworkReady = false.
+                        // Host-driven network config. See `Lumina.run`
+                        // for the v0.7.2 default-flip rationale and the
+                        // DNS NXDOMAIN race that motivates the opt-in.
                         if options.awaitNetworkReady {
                             try await vm.configureNetwork()
                         } else {
+                            // Fire-and-forget: start the config, don't await.
                             Task.detached { try? await vm.configureNetwork() }
                         }
                         let netDone = ContinuousClock.now

--- a/Sources/Lumina/Lumina.swift
+++ b/Sources/Lumina/Lumina.swift
@@ -12,7 +12,7 @@ public struct Lumina {
         try await withVM(options: options) { vm in
             let start = ContinuousClock.now
 
-            try await vm.bootResult().get()
+            try await vm.boot()
 
             // Host-driven network config. Default in v0.7.2+:
             // fire-and-forget, do NOT block exec on `network_ready`.
@@ -40,7 +40,7 @@ public struct Lumina {
 
             // Upload files before exec
             if !options.uploads.isEmpty {
-                try await vm.uploadFilesResult(options.uploads).get()
+                try await vm.uploadFiles(options.uploads)
             }
             // Upload directories before exec
             for dir in options.directoryUploads {
@@ -49,7 +49,7 @@ public struct Lumina {
 
             let remaining = options.timeout - elapsed
             let remainingSeconds = Int(remaining.components.seconds)
-            let result = try await vm.execResult(command, timeout: max(remainingSeconds, 1), env: options.env, cwd: options.workingDirectory, stdin: options.stdin).get()
+            let result = try await vm.exec(command, timeout: max(remainingSeconds, 1), env: options.env, cwd: options.workingDirectory, stdin: options.stdin)
 
             // Download after exec — auto-detect file vs directory on guest
             for dl in options.downloads {
@@ -90,7 +90,7 @@ public struct Lumina {
                 do {
                     try await withVM(options: options) { vm in
                         let start = ContinuousClock.now
-                        try await vm.bootResult().get()
+                        try await vm.boot()
                         let bootDone = ContinuousClock.now
 
                         // v0.7.1 perf: default awaits network_ready so
@@ -119,7 +119,7 @@ public struct Lumina {
 
                         // Upload files before exec
                         if !options.uploads.isEmpty {
-                            try await vm.uploadFilesResult(options.uploads).get()
+                            try await vm.uploadFiles(options.uploads)
                         }
                         for dir in options.directoryUploads {
                             try await vm.uploadDirectory(localPath: dir.localPath, remotePath: dir.remotePath)
@@ -193,7 +193,7 @@ public struct Lumina {
         let vm = VM(options: vmOptions)
 
         do {
-            try await vm.bootResult().get()
+            try await vm.boot()
             try await vm.configureNetwork()
         } catch {
             await vm.shutdown()
@@ -202,7 +202,7 @@ public struct Lumina {
 
         let timeoutSecs = max(Int(opts.timeout.components.seconds), 1)
         for (index, cmd) in commands.enumerated() {
-            let result = try await vm.execResult(cmd, timeout: timeoutSecs, env: opts.env).get()
+            let result = try await vm.exec(cmd, timeout: timeoutSecs, env: opts.env)
             guard result.success else {
                 await vm.shutdown()
                 throw LuminaError.sessionFailed(
@@ -212,7 +212,7 @@ public struct Lumina {
         }
 
         // Flush dirty pages before clone capture (same rationale as single-command path).
-        _ = await vm.execResult("sync", timeout: 10)
+        _ = try? await vm.exec("sync", timeout: 10)
 
         guard let clone = await vm.detachClone() else {
             await vm.shutdown()

--- a/Sources/Lumina/Lumina.swift
+++ b/Sources/Lumina/Lumina.swift
@@ -14,20 +14,18 @@ public struct Lumina {
 
             try await vm.bootResult().get()
 
-            // Host-driven network config. Default: await network_ready
-            // before exec — the guarantee users depend on for commands
-            // that send a packet in the first ~20 ms (curl, ping, apt,
-            // dns lookups). v0.7.1 perf work moved the cost from ~2.5s
-            // to ~50-150 ms by shrinking the guest's carrier-wait
-            // timeout, batching the `ip` setup, and using a netlink
-            // subscription for instant notification when eth0 comes up
-            // (see Guest/lumina-agent/internal/network/network.go).
+            // Host-driven network config. Default in v0.7.2+:
+            // fire-and-forget, do NOT block exec on `network_ready`.
+            // Most short agentic commands (echoes, builds, file ops)
+            // don't need a usable network in their first ms; making
+            // every disposable run pay 50–150ms for the rare DNS
+            // command was the wrong default.
             //
-            // Opt-out for speed-first workloads that know they don't
-            // need network: set `options.awaitNetworkReady = false` or
-            // pass `--no-wait-network` on the CLI. The guest agent
-            // still configures the network in a goroutine concurrently
-            // — the opt-out just drops the host-side barrier.
+            // Opt back in via `options.awaitNetworkReady = true` or
+            // `--wait-network` on the CLI when the command hits DNS
+            // immediately (apt update, pip install, curl). See the
+            // RunOptions.awaitNetworkReady docstring for the DNS
+            // NXDOMAIN race that motivates the opt-in path.
             if options.awaitNetworkReady {
                 try await vm.configureNetwork()
             } else {

--- a/Sources/Lumina/Network.swift
+++ b/Sources/Lumina/Network.swift
@@ -39,6 +39,13 @@ public actor Network {
         let vm = VM(options: vmOpts)
         try await vm.boot()
 
+        // Configure the NAT eth0 interface (host-driven; replaces the
+        // udhcpc fallback that was removed from the guest init in
+        // v0.7.2). Network.swift VMs still want NAT outbound for
+        // package installs / DNS even though VM-to-VM traffic flows
+        // over the private eth1 set up via kernel cmdline.
+        try await vm.configureNetwork()
+
         sessions.append((name: sessionName, ip: ip, vm: vm))
 
         if sessions.count == 2 {

--- a/Sources/Lumina/Network.swift
+++ b/Sources/Lumina/Network.swift
@@ -37,7 +37,7 @@ public actor Network {
         vmOpts.networkIP = ip
 
         let vm = VM(options: vmOpts)
-        try await vm.bootResult().get()
+        try await vm.boot()
 
         sessions.append((name: sessionName, ip: ip, vm: vm))
 

--- a/Sources/Lumina/Pool.swift
+++ b/Sources/Lumina/Pool.swift
@@ -108,20 +108,20 @@ public actor Pool {
 
         // Upload files before exec
         if !uploads.isEmpty {
-            try await vm.uploadFilesResult(uploads).get()
+            try await vm.uploadFiles(uploads)
         }
         for dir in directoryUploads {
             try await vm.uploadDirectory(localPath: dir.localPath, remotePath: dir.remotePath)
         }
 
         let timeoutSecs = max(Int(timeout.components.seconds), 1)
-        let result = try await vm.execResult(
+        let result = try await vm.exec(
             command,
             timeout: timeoutSecs,
             env: env,
             cwd: workingDirectory,
             stdin: stdin
-        ).get()
+        )
 
         // Download after exec — auto-detect file vs directory on guest (mirrors Lumina.run)
         for dl in downloads {
@@ -227,7 +227,7 @@ public actor Pool {
         booting += 1
         let vm = VM(options: options)
         do {
-            try await vm.bootResult().get()
+            try await vm.boot()
             try await vm.configureNetwork()
             return vm
         } catch {

--- a/Sources/Lumina/Protocol.swift
+++ b/Sources/Lumina/Protocol.swift
@@ -35,7 +35,17 @@ public enum HostMessage: Sendable {
 // MARK: - Guest Messages (received from guest)
 
 public enum GuestMessage: Sendable, Equatable {
-    case ready
+    /// Initial handshake from the guest agent. Optional fields:
+    ///   - `protocolVersion`: wire-format version the agent speaks. 0
+    ///     means absent (pre-v0.7.2 agent). Hosts can branch on this
+    ///     for forward/backward-compat decisions when a future bump
+    ///     ships breaking changes — without resorting to message-
+    ///     shape probing.
+    ///   - `capabilities`: list of feature strings the agent
+    ///     implements (e.g. `"pty"`, `"port_forward"`,
+    ///     `"network_metrics"`). Empty when absent. Hosts may consult
+    ///     it before issuing capability-gated requests.
+    case ready(protocolVersion: Int, capabilities: [String])
     /// Text output (UTF-8). `data` carries the text verbatim.
     case output(id: String, stream: OutputStream, data: String)
     /// Binary output. `bytes` carries the raw bytes that were base64-encoded
@@ -177,7 +187,12 @@ enum LuminaProtocol {
 
         switch type {
         case "ready":
-            return .ready
+            // protocol_version / capabilities are optional. Pre-v0.7.2
+            // agents omit both and decode as (0, []) — host treats
+            // version=0 as "old agent, no capability negotiation".
+            let protocolVersion = json["protocol_version"] as? Int ?? 0
+            let capabilities = (json["capabilities"] as? [String]) ?? []
+            return .ready(protocolVersion: protocolVersion, capabilities: capabilities)
         case "output":
             guard let id = json["id"] as? String,
                   let streamStr = json["stream"] as? String,

--- a/Sources/Lumina/SessionServer.swift
+++ b/Sources/Lumina/SessionServer.swift
@@ -655,22 +655,20 @@ public final class SessionServer: @unchecked Sendable {
 
     private func handleUpload(localPath: String, remotePath: String, vm: VM, handle: FileHandle) async {
         let upload = FileUpload(localPath: URL(fileURLWithPath: localPath), remotePath: remotePath)
-        let result = await vm.uploadFilesResult([upload])
-        switch result {
-        case .success:
+        do {
+            try await vm.uploadFiles([upload])
             try? writeResponse(.uploadDone(path: remotePath), to: handle)
-        case .failure(let error):
+        } catch {
             try? writeResponse(.error(message: "Upload failed: \(error)"), to: handle)
         }
     }
 
     private func handleDownload(remotePath: String, localPath: String, vm: VM, handle: FileHandle) async {
         let download = FileDownload(remotePath: remotePath, localPath: URL(fileURLWithPath: localPath))
-        let result = await vm.downloadFilesResult([download])
-        switch result {
-        case .success:
+        do {
+            try await vm.downloadFiles([download])
             try? writeResponse(.downloadDone(path: localPath), to: handle)
-        case .failure(let error):
+        } catch {
             try? writeResponse(.error(message: "Download failed: \(error)"), to: handle)
         }
     }

--- a/Sources/Lumina/Types.swift
+++ b/Sources/Lumina/Types.swift
@@ -90,22 +90,32 @@ public struct RunOptions: Sendable {
     public var diskSize: UInt64?
     /// Stdin source. Default `.closed` sends EOF immediately.
     public var stdin: Stdin
-    /// When true (default), `Lumina.run`/`Lumina.stream` block on
-    /// `network_ready` before invoking exec. This is the reliability
-    /// guarantee — commands that send a packet in the first ~20 ms of
-    /// exec (curl, ping, apt, DNS lookups) always see a usable network.
+    /// When true, `Lumina.run`/`Lumina.stream` block on
+    /// `network_ready` before invoking exec — guarantees commands
+    /// that send a packet in the first ~20 ms of exec (curl, ping,
+    /// apt, DNS lookups) always see a usable network.
     ///
-    /// v0.7.1 perf: the cost of this guarantee dropped from ~2.5 s to
-    /// ~50–150 ms after shrinking the guest's carrier-wait timeout,
-    /// batching the `ip` setup, and switching to netlink-based carrier
-    /// notification. The default is now both safe and fast — users no
-    /// longer have to choose.
+    /// **Default flipped to `false` in v0.7.2** (audit follow-up).
+    /// Rationale: the audit observed that the ~50–150 ms cost is
+    /// paid on every disposable run regardless of whether the
+    /// command needs network, and most short agentic commands
+    /// (echoes, builds, file ops) don't. Network-using commands on
+    /// Linux retry naturally on `ENETDOWN` for TCP/UDP — the host
+    /// driver still fires `configure_network` concurrently in the
+    /// background, the route is typically up within 50 ms.
     ///
-    /// Set to `false` to skip the host-side barrier (guest still runs
-    /// `configure_network` in a goroutine concurrently). Use this only
-    /// for workloads that KNOW they won't touch the network in the
-    /// first milliseconds of exec. Documented as `--no-wait-network`
-    /// on the CLI.
+    /// **Caveat (read this before opt-out cargo-culting):**
+    /// `getaddrinfo` against an unreachable resolver returns
+    /// `NXDOMAIN` immediately without retry. Commands that hit DNS
+    /// in their first millisecond (`apt update`, `pip install`,
+    /// `curl example.com`) will fail with "Could not resolve host"
+    /// roughly 0–5% of the time on a cold disposable VM. If your
+    /// workload is DNS-sensitive, set this to `true` (or pass
+    /// `--wait-network` on the CLI). The guarantee is what it
+    /// always was — only the default changed.
+    ///
+    /// CLI: `--wait-network` opts in. The legacy `--no-wait-network`
+    /// flag is kept as a deprecated no-op alias for one release.
     public var awaitNetworkReady: Bool
 
     public static let `default` = RunOptions()
@@ -124,7 +134,7 @@ public struct RunOptions: Sendable {
         workingDirectory: String? = nil,
         diskSize: UInt64? = nil,
         stdin: Stdin = .closed,
-        awaitNetworkReady: Bool = true
+        awaitNetworkReady: Bool = false
     ) {
         self.timeout = timeout
         self.memory = memory

--- a/Sources/Lumina/VM.swift
+++ b/Sources/Lumina/VM.swift
@@ -219,6 +219,18 @@ public actor VM {
         )
     }
 
+    /// Boot the VM and complete the vsock handshake. After this returns
+    /// successfully, `exec()` works against the guest agent.
+    ///
+    /// **Network contract (v0.7.2+):** `boot()` does NOT configure the
+    /// NAT eth0 interface. The default eth0 link comes up with carrier
+    /// but no IP/route. Call `configureNetwork()` explicitly if you
+    /// need NAT outbound (DNS, internet). Every convenience entry point
+    /// (`Lumina.run`, `Lumina.stream`, `Lumina.createImage`,
+    /// `SessionProcess`, `Pool`, `Network.session`) does this for you.
+    /// Callers driving `VM` directly must do it themselves — the
+    /// previous udhcpc fallback in the guest init was removed in v0.7.2
+    /// because it raced the host-driven config.
     public func boot() async throws(LuminaError) {
         guard _state == .idle else {
             throw .bootFailed(underlying: VMError.invalidState("Cannot boot from state: \(_state)"))

--- a/Sources/Lumina/VM.swift
+++ b/Sources/Lumina/VM.swift
@@ -223,10 +223,11 @@ public actor VM {
     /// successfully, `exec()` works against the guest agent.
     ///
     /// **Network contract (v0.7.2+):** `boot()` does NOT configure the
-    /// NAT eth0 interface. The default eth0 link comes up with carrier
-    /// but no IP/route. Call `configureNetwork()` explicitly if you
-    /// need NAT outbound (DNS, internet). Every convenience entry point
-    /// (`Lumina.run`, `Lumina.stream`, `Lumina.createImage`,
+    /// NAT eth0 interface. eth0 stays admin-down with no IP/route until
+    /// something brings it up. Call `configureNetwork()` explicitly if
+    /// you need NAT outbound (DNS, internet) — it runs `ip link set
+    /// eth0 up` plus addr/route assignment. Every convenience entry
+    /// point (`Lumina.run`, `Lumina.stream`, `Lumina.createImage`,
     /// `SessionProcess`, `Pool`, `Network.session`) does this for you.
     /// Callers driving `VM` directly must do it themselves — the
     /// previous udhcpc fallback in the guest init was removed in v0.7.2

--- a/Sources/Lumina/VM.swift
+++ b/Sources/Lumina/VM.swift
@@ -813,6 +813,21 @@ public actor VM {
         return now
     }
 
+    // MARK: - Deprecated Result Wrapper
+
+    /// Deprecated `Result`-returning wrapper around `boot()`. Kept for one
+    /// release to avoid silently breaking library callers that linked
+    /// against v0.7.1 or earlier. Migrate to `try await vm.boot()`.
+    @available(*, deprecated, renamed: "boot()", message: "Use try await vm.boot() — the throwing API matches every other VM method.")
+    public func bootResult() async -> Result<Void, LuminaError> {
+        do {
+            try await boot()
+            return .success(())
+        } catch {
+            return .failure(error)
+        }
+    }
+
     // MARK: - File Transfer
 
     /// Upload files to the guest. Must be called after boot().

--- a/Sources/Lumina/VM.swift
+++ b/Sources/Lumina/VM.swift
@@ -813,31 +813,6 @@ public actor VM {
         return now
     }
 
-    // MARK: - Internal Result API
-
-    public func bootResult() async -> Result<Void, LuminaError> {
-        do {
-            try await boot()
-            return .success(())
-        } catch {
-            return .failure(error)
-        }
-    }
-
-    func execResult(
-        _ command: String,
-        timeout: Int = 60,
-        env: [String: String] = [:],
-        cwd: String? = nil,
-        stdin: Stdin = .closed
-    ) async -> Result<RunResult, LuminaError> {
-        do {
-            return .success(try await exec(command, timeout: timeout, env: env, cwd: cwd, stdin: stdin))
-        } catch {
-            return .failure(error)
-        }
-    }
-
     // MARK: - File Transfer
 
     /// Upload files to the guest. Must be called after boot().
@@ -941,24 +916,6 @@ public actor VM {
         }
         guard extractProcess.terminationStatus == 0 else {
             throw .downloadFailed(path: remotePath, reason: "tar extract exited with code \(extractProcess.terminationStatus)")
-        }
-    }
-
-    func uploadFilesResult(_ uploads: [FileUpload]) async -> Result<Void, LuminaError> {
-        do {
-            try await uploadFiles(uploads)
-            return .success(())
-        } catch {
-            return .failure(error)
-        }
-    }
-
-    func downloadFilesResult(_ downloads: [FileDownload]) async -> Result<Void, LuminaError> {
-        do {
-            try await downloadFiles(downloads)
-            return .success(())
-        } catch {
-            return .failure(error)
         }
     }
 

--- a/Sources/Lumina/VM.swift
+++ b/Sources/Lumina/VM.swift
@@ -194,6 +194,23 @@ public actor VM {
     /// Expose the current disk clone for image creation workflows.
     public var diskClone: DiskClone? { clone }
 
+    /// Wire-format protocol version the guest agent reported on its
+    /// `ready` frame. 0 when no handshake has happened yet, or when
+    /// the guest pre-dates v0.7.2 (no `protocol_version` field on
+    /// `ready`). Diagnostic only today; future host code can branch
+    /// on this to refuse incompatible guests rather than misdecoding.
+    public var guestProtocolVersion: Int {
+        commandRunner?.guestProtocolVersion ?? 0
+    }
+
+    /// Capability strings the guest agent reported on its `ready`
+    /// frame. Empty when no handshake has happened yet, or when the
+    /// guest pre-dates v0.7.2. Hosts can consult this before issuing
+    /// capability-gated requests like `pty_exec` or `port_forward_start`.
+    public var guestCapabilities: [String] {
+        commandRunner?.guestCapabilities ?? []
+    }
+
     public init(options: VMOptions = .default) {
         self.options = options
         self.imageStore = ImageStore()
@@ -613,9 +630,14 @@ public actor VM {
             config.cpuCount = options.cpuCount
             config.memorySize = options.memory
 
-            // Boot loader + storage.
+            // Boot loader + storage. configMs is recorded once at the
+            // end of the config block (after VZ instantiation + delegate
+            // install), matching the agent path's single-accumulation
+            // pattern. The earlier double-call here was numerically
+            // correct (both calls used `+=`) but split a single
+            // semantic phase into two redundant writes, making the
+            // boot trace harder to reason about.
             try EFIBootable(config: cfg).apply(to: config)
-            phaseMark = recordPhase(\.configMs, since: phaseMark)
 
             // Serial console — capture guest output for diagnostics.
             let serialPort = VZVirtioConsoleDeviceSerialPortConfiguration()

--- a/Sources/lumina-cli/CLI.swift
+++ b/Sources/lumina-cli/CLI.swift
@@ -105,84 +105,11 @@ struct Run: AsyncParsableCommand {
             throw ExitCode.failure
         }
 
-        var parsedEnv: [String: String] = [:]
-        for pair in env {
-            guard let eqIndex = pair.firstIndex(of: "=") else {
-                FileHandle.standardError.write(Data("lumina: invalid env '\(pair)'. Use KEY=VAL format\n".utf8))
-                throw ExitCode.failure
-            }
-            let key = String(pair[pair.startIndex..<eqIndex])
-            let value = String(pair[pair.index(after: eqIndex)...])
-            parsedEnv[key] = value
-        }
-
-        // Parse --copy: auto-detect file vs directory from local path
-        var parsedUploads: [FileUpload] = []
-        var parsedDirUploads: [DirectoryUpload] = []
-        for spec in copy {
-            guard let colonIndex = spec.firstIndex(of: ":") else {
-                FileHandle.standardError.write(Data("lumina: invalid --copy '\(spec)'. Use local:remote format\n".utf8))
-                throw ExitCode.failure
-            }
-            let localStr = String(spec[spec.startIndex..<colonIndex])
-            let remote = String(spec[spec.index(after: colonIndex)...])
-            let localURL = URL(fileURLWithPath: localStr)
-            var isDir: ObjCBool = false
-            guard FileManager.default.fileExists(atPath: localURL.path, isDirectory: &isDir) else {
-                FileHandle.standardError.write(Data("lumina: not found: \(localStr)\n".utf8))
-                throw ExitCode.failure
-            }
-            if isDir.boolValue {
-                parsedDirUploads.append(DirectoryUpload(localPath: localURL, remotePath: remote))
-            } else {
-                let mode = FileManager.default.isExecutableFile(atPath: localURL.path) ? "0755" : "0644"
-                parsedUploads.append(FileUpload(localPath: localURL, remotePath: remote, mode: mode))
-            }
-        }
-
-        // Parse --download: auto-detected as file vs directory at runtime on guest
-        var parsedDownloads: [FileDownload] = []
-        for spec in download {
-            guard let colonIndex = spec.firstIndex(of: ":") else {
-                FileHandle.standardError.write(Data("lumina: invalid --download '\(spec)'. Use remote:local format\n".utf8))
-                throw ExitCode.failure
-            }
-            let remote = String(spec[spec.startIndex..<colonIndex])
-            let localStr = String(spec[spec.index(after: colonIndex)...])
-            let localURL = URL(fileURLWithPath: localStr)
-            parsedDownloads.append(FileDownload(remotePath: remote, localPath: localURL))
-        }
-
-        // Parse --volume: host path (starts with / or .) = mount, otherwise = named volume
-        var parsedMounts: [MountPoint] = []
+        let parsedEnv = try parseEnvSpecs(env)
+        let (parsedUploads, parsedDirUploads) = try parseCopySpecs(copy)
+        let parsedDownloads = try parseDownloadSpecs(download)
         let volumeStore = VolumeStore()
-        for spec in volume {
-            guard let colonIndex = spec.firstIndex(of: ":") else {
-                FileHandle.standardError.write(Data("lumina: invalid --volume '\(spec)'. Use path_or_name:guest_path\n".utf8))
-                throw ExitCode.failure
-            }
-            let left = String(spec[spec.startIndex..<colonIndex])
-            let guestPath = String(spec[spec.index(after: colonIndex)...])
-
-            if left.hasPrefix("/") || left.hasPrefix(".") {
-                // Host directory mount
-                let hostURL = URL(fileURLWithPath: left)
-                var isDir: ObjCBool = false
-                guard FileManager.default.fileExists(atPath: hostURL.path, isDirectory: &isDir), isDir.boolValue else {
-                    FileHandle.standardError.write(Data("lumina: not a directory: \(left)\n".utf8))
-                    throw ExitCode.failure
-                }
-                parsedMounts.append(MountPoint(hostPath: hostURL, guestPath: guestPath))
-            } else {
-                // Named volume
-                guard let hostDir = volumeStore.resolve(name: left) else {
-                    FileHandle.standardError.write(Data("lumina: volume '\(left)' not found\n".utf8))
-                    throw ExitCode.failure
-                }
-                volumeStore.touch(name: left)
-                parsedMounts.append(MountPoint(hostPath: hostDir, guestPath: guestPath))
-            }
-        }
+        let parsedMounts = try parseVolumeSpecs(volume, volumeStore: volumeStore)
 
         var parsedDiskSize: UInt64? = nil
         if let ds = resolvedDiskSize {
@@ -1278,14 +1205,7 @@ struct Exec: AsyncParsableCommand {
         }
         let timeoutSecs = Int(parsedTimeout.components.seconds)
 
-        var parsedEnv: [String: String] = [:]
-        for pair in env {
-            guard let eqIndex = pair.firstIndex(of: "=") else {
-                FileHandle.standardError.write(Data("lumina: invalid env '\(pair)'. Use KEY=VAL\n".utf8))
-                throw ExitCode.failure
-            }
-            parsedEnv[String(pair[..<eqIndex])] = String(pair[pair.index(after: eqIndex)...])
-        }
+        let parsedEnv = try parseEnvSpecs(env)
 
         let client = SessionClient()
         do {
@@ -1950,78 +1870,11 @@ struct PoolRun: AsyncParsableCommand {
             FileHandle.standardError.write(Data("lumina: invalid memory: \(memory)\n".utf8))
             throw ExitCode.failure
         }
-        var parsedEnv: [String: String] = [:]
-        for pair in env {
-            guard let eqIndex = pair.firstIndex(of: "=") else {
-                FileHandle.standardError.write(Data("lumina: invalid env '\(pair)'. Use KEY=VAL format\n".utf8))
-                throw ExitCode.failure
-            }
-            parsedEnv[String(pair[pair.startIndex..<eqIndex])] = String(pair[pair.index(after: eqIndex)...])
-        }
-
-        // Parse --copy: auto-detect file vs directory from local path
-        var parsedUploads: [FileUpload] = []
-        var parsedDirUploads: [DirectoryUpload] = []
-        for spec in copy {
-            guard let colonIndex = spec.firstIndex(of: ":") else {
-                FileHandle.standardError.write(Data("lumina: invalid --copy '\(spec)'. Use local:remote format\n".utf8))
-                throw ExitCode.failure
-            }
-            let localStr = String(spec[spec.startIndex..<colonIndex])
-            let remote = String(spec[spec.index(after: colonIndex)...])
-            let localURL = URL(fileURLWithPath: localStr)
-            var isDir: ObjCBool = false
-            guard FileManager.default.fileExists(atPath: localURL.path, isDirectory: &isDir) else {
-                FileHandle.standardError.write(Data("lumina: not found: \(localStr)\n".utf8))
-                throw ExitCode.failure
-            }
-            if isDir.boolValue {
-                parsedDirUploads.append(DirectoryUpload(localPath: localURL, remotePath: remote))
-            } else {
-                let mode = FileManager.default.isExecutableFile(atPath: localURL.path) ? "0755" : "0644"
-                parsedUploads.append(FileUpload(localPath: localURL, remotePath: remote, mode: mode))
-            }
-        }
-
-        // Parse --download: auto-detected as file vs directory at runtime on guest
-        var parsedDownloads: [FileDownload] = []
-        for spec in download {
-            guard let colonIndex = spec.firstIndex(of: ":") else {
-                FileHandle.standardError.write(Data("lumina: invalid --download '\(spec)'. Use remote:local format\n".utf8))
-                throw ExitCode.failure
-            }
-            let remote = String(spec[spec.startIndex..<colonIndex])
-            let localStr = String(spec[spec.index(after: colonIndex)...])
-            parsedDownloads.append(FileDownload(remotePath: remote, localPath: URL(fileURLWithPath: localStr)))
-        }
-
-        // Parse --volume: applied at pool boot time (VM-level config)
-        var parsedMounts: [MountPoint] = []
+        let parsedEnv = try parseEnvSpecs(env)
+        let (parsedUploads, parsedDirUploads) = try parseCopySpecs(copy)
+        let parsedDownloads = try parseDownloadSpecs(download)
         let volumeStore = VolumeStore()
-        for spec in volume {
-            guard let colonIndex = spec.firstIndex(of: ":") else {
-                FileHandle.standardError.write(Data("lumina: invalid --volume '\(spec)'. Use path_or_name:guest_path\n".utf8))
-                throw ExitCode.failure
-            }
-            let left = String(spec[spec.startIndex..<colonIndex])
-            let guestPath = String(spec[spec.index(after: colonIndex)...])
-            if left.hasPrefix("/") || left.hasPrefix(".") {
-                let hostURL = URL(fileURLWithPath: left)
-                var isDir: ObjCBool = false
-                guard FileManager.default.fileExists(atPath: hostURL.path, isDirectory: &isDir), isDir.boolValue else {
-                    FileHandle.standardError.write(Data("lumina: not a directory: \(left)\n".utf8))
-                    throw ExitCode.failure
-                }
-                parsedMounts.append(MountPoint(hostPath: hostURL, guestPath: guestPath))
-            } else {
-                guard let hostDir = volumeStore.resolve(name: left) else {
-                    FileHandle.standardError.write(Data("lumina: volume '\(left)' not found\n".utf8))
-                    throw ExitCode.failure
-                }
-                volumeStore.touch(name: left)
-                parsedMounts.append(MountPoint(hostPath: hostDir, guestPath: guestPath))
-            }
-        }
+        let parsedMounts = try parseVolumeSpecs(volume, volumeStore: volumeStore)
 
         let opts = VMOptions(memory: parsedMemory, cpuCount: cpus, image: image, mounts: parsedMounts)
 

--- a/Sources/lumina-cli/CLI.swift
+++ b/Sources/lumina-cli/CLI.swift
@@ -136,7 +136,10 @@ struct Run: AsyncParsableCommand {
             awaitNetworkReady: waitNetwork
         )
 
-        if noWaitNetwork {
+        // Mid-migration scripts may pass both flags. If --wait-network is
+        // also set, the user has clearly opted in — don't shout about the
+        // deprecated alias on top of that.
+        if noWaitNetwork && !waitNetwork {
             FileHandle.standardError.write(Data(
                 "lumina: --no-wait-network is a no-op in v0.7.2+ (default behaviour). Pass --wait-network to opt back into the v0.7.1 default.\n".utf8
             ))

--- a/Sources/lumina-cli/CLI.swift
+++ b/Sources/lumina-cli/CLI.swift
@@ -49,7 +49,10 @@ struct Run: AsyncParsableCommand {
     @Flag(name: .long, help: "Run in PTY mode (interactive terminal) — use `exec --pty` against a session")
     var pty: Bool = false
 
-    @Flag(name: .customLong("no-wait-network"), help: "Skip the host-side wait for network_ready. Guest still configures the network concurrently; this just drops the barrier. Only use when you KNOW the command won't touch DNS/TCP in the first ~20ms. Default (await) is now ~50-150ms on v0.7.1+ so the speedup is small and the reliability cost is real.")
+    @Flag(name: .customLong("wait-network"), help: "Block exec until the guest's network is up (~50-150ms cost). Recommended for commands that hit DNS in their first millisecond (apt update, curl, pip install). Off by default in v0.7.2+.")
+    var waitNetwork: Bool = false
+
+    @Flag(name: .customLong("no-wait-network"), help: "[deprecated] Was the v0.7.1 opt-out flag; v0.7.2+ does not wait by default, so this is now a no-op. Use --wait-network to opt back in to the legacy default.")
     var noWaitNetwork: Bool = false
 
     func run() async throws {
@@ -203,8 +206,14 @@ struct Run: AsyncParsableCommand {
             workingDirectory: workdir,
             diskSize: parsedDiskSize,
             stdin: resolveStdin(),
-            awaitNetworkReady: !noWaitNetwork
+            awaitNetworkReady: waitNetwork
         )
+
+        if noWaitNetwork {
+            FileHandle.standardError.write(Data(
+                "lumina: --no-wait-network is a no-op in v0.7.2+ (default behaviour). Pass --wait-network to opt back into the v0.7.1 default.\n".utf8
+            ))
+        }
 
         let format = resolveOutputFormat()
         let shouldStream = resolveStreaming()

--- a/Sources/lumina-cli/SessionProcess.swift
+++ b/Sources/lumina-cli/SessionProcess.swift
@@ -96,7 +96,7 @@ struct SessionServe: AsyncParsableCommand {
         let vm = VM(options: vmOptions)
 
         do {
-            try await vm.bootResult().get()
+            try await vm.boot()
             // Configure network at session boot — one-time cost, all subsequent
             // exec commands have network available at no extra latency.
             try await vm.configureNetwork()

--- a/Sources/lumina-cli/SpecParsers.swift
+++ b/Sources/lumina-cli/SpecParsers.swift
@@ -1,0 +1,113 @@
+// Sources/lumina-cli/SpecParsers.swift
+//
+// Shared parsers for CLI flag specs that more than one subcommand
+// accepts: `--env KEY=VAL`, `--copy local:remote`,
+// `--download remote:local`, `--volume name_or_path:guest`.
+//
+// Each helper writes a friendly error to stderr and throws
+// `ExitCode.failure` on bad input — same shape as the inline parsers
+// they replace, so subcommand callers don't need their own error
+// formatting. Audit follow-up: the duplication between `Run` and
+// `pool run` was ~80 LOC of identical loops.
+import ArgumentParser
+import Foundation
+import Lumina
+
+/// Parse `KEY=VAL` env-var specs. Empty input is allowed (returns
+/// empty map); a missing `=` is a hard error.
+func parseEnvSpecs(_ specs: [String]) throws -> [String: String] {
+    var parsed: [String: String] = [:]
+    for pair in specs {
+        guard let eqIndex = pair.firstIndex(of: "=") else {
+            FileHandle.standardError.write(Data("lumina: invalid env '\(pair)'. Use KEY=VAL format\n".utf8))
+            throw ExitCode.failure
+        }
+        let key = String(pair[pair.startIndex..<eqIndex])
+        let value = String(pair[pair.index(after: eqIndex)...])
+        parsed[key] = value
+    }
+    return parsed
+}
+
+/// Parse `--copy local:remote` specs. Auto-detects file vs directory
+/// from the local path; throws if the local path doesn't exist.
+/// Returns the two-bucket split that callers thread into
+/// `RunOptions.uploads` and `RunOptions.directoryUploads`.
+func parseCopySpecs(_ specs: [String]) throws -> ([FileUpload], [DirectoryUpload]) {
+    var files: [FileUpload] = []
+    var dirs: [DirectoryUpload] = []
+    for spec in specs {
+        guard let colonIndex = spec.firstIndex(of: ":") else {
+            FileHandle.standardError.write(Data("lumina: invalid --copy '\(spec)'. Use local:remote format\n".utf8))
+            throw ExitCode.failure
+        }
+        let localStr = String(spec[spec.startIndex..<colonIndex])
+        let remote = String(spec[spec.index(after: colonIndex)...])
+        let localURL = URL(fileURLWithPath: localStr)
+        var isDir: ObjCBool = false
+        guard FileManager.default.fileExists(atPath: localURL.path, isDirectory: &isDir) else {
+            FileHandle.standardError.write(Data("lumina: not found: \(localStr)\n".utf8))
+            throw ExitCode.failure
+        }
+        if isDir.boolValue {
+            dirs.append(DirectoryUpload(localPath: localURL, remotePath: remote))
+        } else {
+            let mode = FileManager.default.isExecutableFile(atPath: localURL.path) ? "0755" : "0644"
+            files.append(FileUpload(localPath: localURL, remotePath: remote, mode: mode))
+        }
+    }
+    return (files, dirs)
+}
+
+/// Parse `--download remote:local` specs. Path existence is not
+/// checked here — the guest decides at runtime whether the remote
+/// path is a file or directory.
+func parseDownloadSpecs(_ specs: [String]) throws -> [FileDownload] {
+    var parsed: [FileDownload] = []
+    for spec in specs {
+        guard let colonIndex = spec.firstIndex(of: ":") else {
+            FileHandle.standardError.write(Data("lumina: invalid --download '\(spec)'. Use remote:local format\n".utf8))
+            throw ExitCode.failure
+        }
+        let remote = String(spec[spec.startIndex..<colonIndex])
+        let localStr = String(spec[spec.index(after: colonIndex)...])
+        let localURL = URL(fileURLWithPath: localStr)
+        parsed.append(FileDownload(remotePath: remote, localPath: localURL))
+    }
+    return parsed
+}
+
+/// Parse `--volume name_or_path:guest` specs.
+///
+/// Disambiguation: a leading `/` or `.` means "host directory mount"
+/// (the path must exist and be a directory). Anything else is
+/// resolved against the named-volume store.
+func parseVolumeSpecs(_ specs: [String], volumeStore: VolumeStore) throws -> [MountPoint] {
+    var parsed: [MountPoint] = []
+    for spec in specs {
+        guard let colonIndex = spec.firstIndex(of: ":") else {
+            FileHandle.standardError.write(Data("lumina: invalid --volume '\(spec)'. Use path_or_name:guest_path\n".utf8))
+            throw ExitCode.failure
+        }
+        let left = String(spec[spec.startIndex..<colonIndex])
+        let guestPath = String(spec[spec.index(after: colonIndex)...])
+
+        if left.hasPrefix("/") || left.hasPrefix(".") {
+            let hostURL = URL(fileURLWithPath: left)
+            var isDir: ObjCBool = false
+            guard FileManager.default.fileExists(atPath: hostURL.path, isDirectory: &isDir), isDir.boolValue else {
+                FileHandle.standardError.write(Data("lumina: not a directory: \(left)\n".utf8))
+                throw ExitCode.failure
+            }
+            parsed.append(MountPoint(hostPath: hostURL, guestPath: guestPath))
+        } else {
+            guard let hostDir = volumeStore.resolve(name: left) else {
+                FileHandle.standardError.write(Data("lumina: volume '\(left)' not found\n".utf8))
+                throw ExitCode.failure
+            }
+            volumeStore.touch(name: left)
+            parsed.append(MountPoint(hostPath: hostDir, guestPath: guestPath))
+        }
+    }
+    return parsed
+}

--- a/Tests/LuminaTests/IntegrationTests.swift
+++ b/Tests/LuminaTests/IntegrationTests.swift
@@ -61,6 +61,48 @@ func integrationRunTimeout() async {
     }
 }
 
+/// Audit-fix regression guard (v0.7.2): a command that finishes a hair
+/// after the timeout watchdog fires SIGTERM should land its real exit
+/// code via the soft/hard deadline grace window, not synthesize
+/// `.timeout`. Without this fix, agents retrying non-idempotent ops
+/// repeated work that actually succeeded.
+///
+/// Test shape: timeout 1s on a `sleep 0.95 && exit 7`. The `sleep`
+/// returns naturally just before the 1s soft deadline most of the
+/// time, but on a loaded host the schedule can overshoot. Either way:
+///   - Natural-exit case: exit code 7, no error.
+///   - Late-exit-in-grace-window case: also exit code 7 (the fix
+///     guarantees this — pre-fix it would surface as `.timeout`).
+///   - Hard-overshoot (>1.25s on a *very* loaded host): `.timeout`.
+///     Treated as inconclusive rather than a failure.
+@Test(.enabled(if: integrationEnabled()))
+func integrationTimeoutGraceWindow() async {
+    do {
+        let result = try await Lumina.run(
+            "sleep 0.95 && exit 7",
+            options: RunOptions(timeout: .seconds(1))
+        )
+        // The contract: if the command was within the natural-exit
+        // window OR the post-watchdog grace window, the host MUST
+        // surface the real exit code (7) instead of a synthetic
+        // timeout.
+        #expect(result.exitCode == 7,
+                "Expected exit 7 (natural exit or grace-window reclaim); got \(result.exitCode)")
+    } catch let error as LuminaError {
+        if case .timeout = error {
+            // Hard overshoot — only acceptable on a heavily loaded
+            // host where the command genuinely took >1.25s. Don't
+            // fail the suite on that, but record the slip so it
+            // shows up if it becomes a regression pattern.
+            Issue.record("Grace-window test fell off the cliff to .timeout — host likely loaded; expected exit 7")
+        } else {
+            Issue.record("Expected exit 7 or .timeout, got: \(error)")
+        }
+    } catch {
+        Issue.record("Unexpected error type: \(error)")
+    }
+}
+
 @Test(.enabled(if: integrationEnabled()))
 func integrationVMLifecycle() async throws {
     let vm = VM(options: VMOptions(memory: 512 * 1024 * 1024, cpuCount: 2))

--- a/Tests/LuminaTests/IntegrationTests.swift
+++ b/Tests/LuminaTests/IntegrationTests.swift
@@ -67,34 +67,53 @@ func integrationRunTimeout() async {
 /// `.timeout`. Without this fix, agents retrying non-idempotent ops
 /// repeated work that actually succeeded.
 ///
-/// Test shape: timeout 1s on a `sleep 0.95 && exit 7`. The `sleep`
-/// returns naturally just before the 1s soft deadline most of the
-/// time, but on a loaded host the schedule can overshoot. Either way:
-///   - Natural-exit case: exit code 7, no error.
-///   - Late-exit-in-grace-window case: also exit code 7 (the fix
-///     guarantees this — pre-fix it would surface as `.timeout`).
-///   - Hard-overshoot (>1.25s on a *very* loaded host): `.timeout`.
-///     Treated as inconclusive rather than a failure.
+/// Test shape: timeout 1s on a SIGTERM-trapping shell that would
+/// otherwise sleep far past the hard deadline:
+///
+///     trap 'exit 7' TERM; sleep 5
+///
+/// At T=1.0s the watchdog fires SIGTERM. The shell's trap runs,
+/// the `sleep` is interrupted, and the shell exits 7 within a few
+/// milliseconds — well inside the 250ms grace window. The natural
+/// exit and the synthetic timeout race, and the fix's contract is
+/// that the natural exit wins.
+///
+/// Why this shape (not `sleep 0.95 && exit 7`):
+///   - With a pre-watchdog natural exit, the test would pass even
+///     pre-fix (handler is still registered when the early `.exit`
+///     arrives) — it doesn't discriminate.
+///   - With this shape, the natural exit STRICTLY arrives after the
+///     watchdog has fired. Pre-fix the handler is unregistered the
+///     instant the watchdog throws, so `.exit(7)` is dropped and
+///     `.timeout` surfaces. Post-fix the handler stays registered
+///     through soft+250ms, so `.exit(7)` lands.
+///
+/// Failure modes:
+///   - exit 7: post-fix correct.
+///   - exit 143 (SIGTERM kill code): the shell's trap didn't run —
+///     possible on shells that don't honor `trap` while a child
+///     foreground process is alive. Recorded but not failed because
+///     it indicates a guest-image quirk, not a host regression.
+///   - .timeout: the fix is missing OR the host is so loaded that
+///     even the trap shell overshot the 1.25s hard deadline. The
+///     latter is wildly unlikely on CI; treat as a failure since
+///     this is the regression guard.
 @Test(.enabled(if: integrationEnabled()))
 func integrationTimeoutGraceWindow() async {
     do {
         let result = try await Lumina.run(
-            "sleep 0.95 && exit 7",
+            "trap 'exit 7' TERM; sleep 5",
             options: RunOptions(timeout: .seconds(1))
         )
-        // The contract: if the command was within the natural-exit
-        // window OR the post-watchdog grace window, the host MUST
-        // surface the real exit code (7) instead of a synthetic
-        // timeout.
+        if result.exitCode == 143 {
+            Issue.record("Guest shell didn't honor TERM trap (got 143). Test inconclusive on this image — fix coverage not exercised.")
+            return
+        }
         #expect(result.exitCode == 7,
-                "Expected exit 7 (natural exit or grace-window reclaim); got \(result.exitCode)")
+                "Expected exit 7 from grace-window reclaim; got \(result.exitCode). Pre-fix would surface .timeout; the soft/hard deadline keeps the handler registered so the trap's exit lands.")
     } catch let error as LuminaError {
         if case .timeout = error {
-            // Hard overshoot — only acceptable on a heavily loaded
-            // host where the command genuinely took >1.25s. Don't
-            // fail the suite on that, but record the slip so it
-            // shows up if it becomes a regression pattern.
-            Issue.record("Grace-window test fell off the cliff to .timeout — host likely loaded; expected exit 7")
+            Issue.record("Grace-window reclaim missing — handler was unregistered before trap's `.exit(7)` arrived. This is the bug the soft/hard deadline pattern is supposed to prevent.")
         } else {
             Issue.record("Expected exit 7 or .timeout, got: \(error)")
         }

--- a/Tests/LuminaTests/ProtocolTests.swift
+++ b/Tests/LuminaTests/ProtocolTests.swift
@@ -45,9 +45,27 @@ import Testing
 // MARK: - Guest Message Tests
 
 @Test func decodeReadyMessage() throws {
+    // Pre-v0.7.2 agents omit protocol_version + capabilities. Decoder
+    // defaults them to (0, []) so old guests stay compatible.
     let data = Data("{\"type\":\"ready\"}\n".utf8)
     let msg = try Protocol.decodeGuest(data)
-    #expect(msg == .ready)
+    #expect(msg == .ready(protocolVersion: 0, capabilities: []))
+}
+
+@Test func decodeReadyMessageWithProtocolVersion() throws {
+    // v0.7.2+ agents emit protocol_version + capabilities so the host
+    // can branch on guest features without message-shape probing.
+    let json = #"{"type":"ready","protocol_version":1,"capabilities":["pty","port_forward","network_metrics"]}"# + "\n"
+    let msg = try Protocol.decodeGuest(Data(json.utf8))
+    #expect(msg == .ready(protocolVersion: 1, capabilities: ["pty", "port_forward", "network_metrics"]))
+}
+
+@Test func decodeReadyMessagePartialCapabilities() throws {
+    // Capabilities is just a list of strings — order matters for
+    // equality but the host should treat it as a set in practice.
+    let json = #"{"type":"ready","protocol_version":2,"capabilities":[]}"# + "\n"
+    let msg = try Protocol.decodeGuest(Data(json.utf8))
+    #expect(msg == .ready(protocolVersion: 2, capabilities: []))
 }
 
 @Test func decodeOutputMessage() throws {

--- a/Tests/LuminaTests/TypesTests.swift
+++ b/Tests/LuminaTests/TypesTests.swift
@@ -59,7 +59,8 @@ import Testing
 
 @Test func guestMessageHeartbeatEquality() {
     #expect(GuestMessage.heartbeat == GuestMessage.heartbeat)
-    #expect(GuestMessage.heartbeat != GuestMessage.ready)
+    #expect(GuestMessage.heartbeat != GuestMessage.ready(protocolVersion: 0, capabilities: []))
+    #expect(GuestMessage.heartbeat != GuestMessage.ready(protocolVersion: 1, capabilities: ["pty"]))
 }
 
 @Test func runOptionsWorkingDirectoryDefaultNil() {

--- a/Tests/LuminaTests/TypesTests.swift
+++ b/Tests/LuminaTests/TypesTests.swift
@@ -11,6 +11,9 @@ import Testing
     #expect(opts.image == "default")
     #expect(opts.directoryUploads.isEmpty)
     #expect(opts.directoryDownloads.isEmpty)
+    // v0.7.2 default flip: do NOT block exec on network_ready by default.
+    // Regression guard against an accidental flip-back to true.
+    #expect(opts.awaitNetworkReady == false)
 }
 
 @Test func directoryUploadInit() {


### PR DESCRIPTION
Follow-up to the multi-lens audit (2026-04-26). All five wins + an audit-flagged correctness bug + two code-hygiene cleanups, **plus three review-feedback fixes** (commits 6–8) **and four follow-up fixes from a second review** (commits 9–12).

## Status

| Win                                                                      | Status                                                                                                                                                               |
| ------------------------------------------------------------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
| #1 kernel `CONFIG_MD=n` / `CONFIG_RAID6_PQ=n`                            | ✅ already in source at `Guest/build-kernel.sh:133-144` (verified). Savings (~500 ms cold boot) ship on the next `lumina-v*` tag — `release.yml` rebuilds the image. |
| #2 redundant `configMs +=` on EFI path                                   | ✅                                                                                                                                                                   |
| #3 flip `RunOptions.awaitNetworkReady` default to `false`                | ✅ flipped + new `--wait-network` opt-in flag + deprecated no-op `--no-wait-network` warning (review-fix: warning suppressed when both flags set)                    |
| #4 drop `udhcpc` from guest init                                         | ✅ + review-fix: explicit `configureNetwork` in `Network.swift`, documented contract on `VM.boot()`                                                                  |
| #5 `protocol_version` + `capabilities` on guest `ready` frame            | ✅ (review-fix: `ProtocolVersion` now typed as `Version` alias for greppable v2 branching)                                                                           |
| Audit-flagged bug: dispatcher silent-drop on timeout race                | ✅ soft/hard deadline; review-fix: dropped unused late-exit stash; **second review-fix:** integration test now actually exercises the grace-window reclaim path      |
| Cleanup: `bootResult`/`execResult`/`uploadFilesResult` passthroughs      | ✅ dropped (review-fix: `bootResult` restored as deprecated shim — was public)                                                                                       |
| Cleanup: CLI `--env` / `--copy` / `--download` / `--volume` parser dedup | ✅ extracted to `SpecParsers.swift`                                                                                                                                  |

## Commits (12)

1. **`df8aa05`** — `feat: protocol handshake + boot trace + udhcpc cleanup (audit wins)`
   Wins #2, #4, #5 bundled (configMs cleanup, udhcpc removal, protocol_version + capabilities on `ready`).

2. **`be48139`** — `perf+feat: flip awaitNetworkReady default + add --wait-network opt-in`
   Win #3. The v0.7.1 docstring conflict was surfaced in the original PR body and you authorised the flip. `RunOptions.awaitNetworkReady` default goes `true → false`. CLI ships a new `--wait-network` flag for DNS-sensitive workloads (`apt update`, `pip install`, `curl`); the legacy `--no-wait-network` flag is kept as a deprecated no-op alias for one release. `RunOptions.awaitNetworkReady` docstring rewritten with the real DNS NXDOMAIN caveat that motivated the deferral.

3. **`e7ec18d`** — `fix(timeout): natural exit beats synthetic timeout via grace window`
   Audit-flagged correctness bug. When a slow command finished a hair after the timeout watchdog fired, its exit message arrived at a dispatcher whose handler was already deregistered — host returned `.timeout`, guest had returned 0, and agents retrying non-idempotent ops repeated work that succeeded. Two-part fix: (a) **soft/hard deadline pattern** in `exec()` and `execStream()` — watchdog fires SIGTERM at the soft deadline but the loop keeps reading the stream until the hard deadline (soft + 250 ms). A natural exit during the grace window beats the synthetic timeout. (b) **late-exit stash** — orphan `.exit(id:)` messages are now stashed in a bounded map keyed by id (TTL 30s, pruned on insert) instead of dropped. `consumeRecentExit(id:)` exposes it for post-mortem reclaim. _(See `4dae98e` below — review feedback dropped the stash as scaffolding without a consumer; the soft/hard deadline alone closes the race.)_

4. **`a9c0127`** — `refactor: drop bootResult/execResult/uploadFilesResult passthroughs`
   `VM.swift` had four `*Result` wrappers that just wrapped the throwing API in a `Result<T, LuminaError>`. Every callsite did `.get()` to unwrap. Replace `try await vm.xResult().get()` with `try await vm.x()` across 6 files. SessionServer's two switch-on-Result sites become do/catch. `_ = await vm.execResult("sync", ...)` becomes `_ = try? await vm.exec(...)`. ~50 LOC removed, no behavior change. _(See `d1191bf` below — `bootResult` was public; restored as a deprecation shim.)_

5. **`dfede81`** — `refactor(cli): extract --env / --copy / --download / --volume parsers`
   `Run`, `Exec`, and `pool run` parsed the same flag formats inline. Extract `parseEnvSpecs`, `parseCopySpecs`, `parseDownloadSpecs`, `parseVolumeSpecs` into a new `Sources/lumina-cli/SpecParsers.swift`. Each writes the same friendly error to stderr and throws `ExitCode.failure`. -120 LOC of dup, +110 LOC of shared helpers. The win is single-source-of-truth for the spec formats.

6. **`d1191bf`** — `fix(api): restore deprecated VM.bootResult() shim`
   Review fix (Important #1). `a9c0127` dropped `bootResult()` without flagging that it was part of the public surface — library callers linking against v0.7.1 or earlier would hit a hard compile break. Restored as `@available(*, deprecated, renamed: "boot()")` shim for one release; the throwing API is the migration target. The other three wrappers (`execResult`, `uploadFilesResult`, `downloadFilesResult`) were internal and stay gone.

7. **`c85b488`** — `fix(network): wire configureNetwork in Network.swift; document VM.boot() contract`
   Review fix (Important #2). `df8aa05`'s udhcpc removal silently regressed two paths the commit message wrongly claimed were covered:
   - `Network.swift` was listed as "all call it" but never invoked `vm.configureNetwork()` — its VMs got NAT eth0 with carrier UP and no IP. Fixed: `Network.session()` now calls `configureNetwork()` after `boot()` like every other internal entry point.
   - Library callers driving the public `VM` actor directly (Layer 3 — Lifecycle in CLAUDE.md) had been transparently served by udhcpc. Added an explicit network-contract paragraph to `VM.boot()`'s docstring spelling out the obligation. Corrected the `build-image.sh` comment that misrepresented Network.swift as a caller.

8. **`4dae98e`** — `refactor(timeout): drop unused late-exit stash + integration regression test`
   Review fix (Important #3 + #4). The `_recentExits` stash + `stashLateExit`/`consumeRecentExit` pair from `e7ec18d` was dead code — nothing called `consumeRecentExit`, and tracing the lifecycle showed why: the dispatcher only stashes orphans AFTER `exec()`'s `defer { unregisterExecHandler(id) }` runs (i.e., after `exec()` already returned/threw). The actual fix that closes the audit-flagged race is the soft/hard deadline pattern. The stash was scaffolding for a hypothetical post-mortem reclaim path that never materialised. Dropped (-40 LOC). Added `integrationTimeoutGraceWindow` — `sleep 0.95 && exit 7` with timeout 1s. _(See `e211fe2` below — second review caught that this shape doesn't actually exercise the grace-window reclaim. Test rewritten to use a SIGTERM-trapping shell.)_

### Second review — follow-up fixes (4)

9. **`e211fe2`** — `test(timeout): exercise grace-window reclaim with trap shell`
   Important fix. The `sleep 0.95 && exit 7` shape didn't discriminate fix-present from fix-absent: natural exit before T=1.0s passes pre-fix and post-fix identically; SIGTERM kill of `sh` mid-sleep surfaces exit -1 (Go's signal-killed `exec.ExitError`), not 7 or 143. Replaced with `trap 'exit 7' TERM; sleep 5` — at T=1.0s the watchdog fires SIGTERM, the trap runs, the shell exits 7 within ms (well inside the 250ms grace window). Pre-fix the handler is unregistered the instant the watchdog throws → `.exit(7)` dropped → `.timeout` surfaces. Post-fix the handler stays registered through soft+250ms → `.exit(7)` lands. Now actually load-bearing as a regression guard.

10. **`487bbc7`** — `fix(cli): suppress --no-wait-network warning when --wait-network set`
    Minor fix. Mid-migration scripts may pass both flags. The warning text claimed `--no-wait-network` was "default behaviour" and pointed at `--wait-network` — but if the user already passed `--wait-network`, the deprecation warning is double-noise on top of the explicit opt-in. Gate the warning on `noWaitNetwork && !waitNetwork`. Single-flag invocations still see the deprecation nudge.

11. **`2eb2a4c`** — `docs(runner): clarify orphan-exit drop comment for PTY path`
    Minor fix. The orphan-exit drop comment in `dispatchMessage` overclaimed: the soft/hard deadline grace window is in `exec()` and `execStream()` only — `ptyExec()` has no host-side deadline pattern (PTY timeout is enforced solely by the guest's `gracefulKill` — SIGTERM, then SIGKILL after 5s). A late PTY exit can still land in the orphan branch if the consumer cancels or drops the stream. Drop is bounded by the guest's SIGKILL fallback. Pre-existing for the PTY path — comment-only clarification.

12. **`39665e7`** — `refactor(protocol): type ProtocolVersion as Version alias`
    Minor fix. `ProtocolVersion` was a bare `int`. Introduce `type Version int` for the const and the `ReadyMsg.ProtocolVersion` field. Wire format unchanged (Go encodes typed numeric aliases as the underlying int; `omitempty` zero-value semantics identical). Future v2 branching is greppable; `go vet` flags missed comparison sites.

## Verification

- `swift build` — clean (zero warnings)
- 340 unit tests pass (full non-integration suite, `swift test --skip Integration`)
- 2 new Go-side tests: `TestNewReady_PopulatesProtocolVersionAndCapabilities`, `TestReadyMsg_OmitsEmptyOptionalFields`
- 3 new Swift-side tests: `decodeReadyMessage` (backward compat), `decodeReadyMessageWithProtocolVersion`, `decodeReadyMessagePartialCapabilities`
- 1 new integration test: `integrationTimeoutGraceWindow` (gated on `LUMINA_INTEGRATION_TESTS=1`) — now exercises grace-window reclaim, not natural-exit
- Go cross-compile clean for `linux/arm64` after `Version` alias change; `go test ./internal/protocol/` passes
- Live smoke (post-flip):
  - `lumina run "echo hello"` → ~330 ms exec (default, no flag)
  - `lumina run --wait-network "echo hello"` → ~400 ms exec (gateway log on stderr)
  - `lumina run --no-wait-network "echo ..."` → deprecation warning emitted to stderr
  - `lumina run --wait-network --no-wait-network "echo ..."` → no deprecation warning (suppressed on explicit opt-in)
  - `lumina run --copy /tmp/nonexistent:/tmp/x "..."` → friendly `not found` error from new helper

## Out of scope

- **Win #1 image rebuild.** Source is correct in `build-kernel.sh:133-144` (verified at lines 180-181 by the kernel-config gate). The savings ship with the next `lumina-v*` tag — `release.yml` rebuilds the kernel + image automatically on tag push.
- **`bench.yml` mode-label rename.** Now that the default no longer awaits network, the `default-await` vs `--no-wait-network` mode labels are misleading. Followup.

## Release notes / user-visible changes

In addition to the items in **Risks / behavior changes** below, two smaller user-visible deltas worth flagging for anyone scripting against this:

- **`Exec`'s env-parser error string** changed from `"Use KEY=VAL"` to `"Use KEY=VAL format"` after the `SpecParsers` extraction in `dfede81`. Now matches `Run` and `pool run`. Strict improvement; mention in case any test scripts pattern-match the exact string.
- **`LUMINA_BOOT_TRACE=1` `configMs` numbers will drop on the EFI path** post-`df8aa05`. Pre-fix the field was double-accumulated via two `+=` on the same code path (numerically correct sum, but two writes per phase). Post-fix it's single-accumulation matching the agent path. Anyone tracking trace numbers across versions should expect a nominal drop in EFI-path `configMs` without any actual perf regression.

## Risks / behavior changes

- **udhcpc removal:** library callers using the public `VM` actor directly (Layer 3 — Lifecycle) without calling `vm.configureNetwork()` will boot with eth0 carrier-up but unconfigured. All convenience paths (`Lumina.run` / `Lumina.stream` / `Lumina.createImage`, `SessionProcess`, `Pool`, `Network.session`) call it. The contract is now documented on `VM.boot()`'s docstring.
- **`awaitNetworkReady` flip:** DNS-sensitive workloads now race on the first millisecond. Mitigation: `--wait-network` opt-in + clear docstring caveat.
- **`GuestMessage.ready` associated values:** source-compatible for `case .ready:` discard patterns; only equality matches needed updating (1 in `ProtocolTests`, 1 in `TypesTests`, both updated).
- **Timeout-race fix changes the error shape for SIGTERM-killable workloads.** Pre-fix: a command that the watchdog SIGTERM'd at T+timeout always surfaced as `LuminaError.timeout`. Post-fix: if the SIGTERM kill completes within the 250 ms grace window, the host returns `RunResult(exitCode: 143, …)` instead — the truthful "command died from SIGTERM" rather than the synthetic timeout. Callers that pattern-match `error == .timeout` to drive retry decisions should also handle `exitCode == 143` (or signal-kill exit codes generally) for the same intent. Genuine hard-overshoot timeouts (>1.25 s past the soft deadline) still surface as `.timeout` unchanged.
- **`VM.bootResult()` deprecated:** callers linked against v0.7.1 or earlier keep working with a deprecation warning; migrate to `try await vm.boot()` to clear the warning. Removal scheduled for the v0.7.x→v0.8 boundary.
